### PR TITLE
FEAT : ODYA-25 애플 로그인

### DIFF
--- a/Odya-iOS.xcodeproj/project.pbxproj
+++ b/Odya-iOS.xcodeproj/project.pbxproj
@@ -11,8 +11,10 @@
 		071FA5242A20A99F00C7B362 /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 071FA5232A20A99F00C7B362 /* LoginView.swift */; };
 		071FA5262A20A9A000C7B362 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 071FA5252A20A9A000C7B362 /* Assets.xcassets */; };
 		071FA5292A20A9A000C7B362 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 071FA5282A20A9A000C7B362 /* Preview Assets.xcassets */; };
+		0732948A2A2C9975008E1026 /* UserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 073294892A2C9975008E1026 /* UserDefaults.swift */; };
 		07B54E062A263B5A00F631EF /* TestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07B54E052A263B5A00F631EF /* TestView.swift */; };
 		07B54E092A26474F00F631EF /* TestAPIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07B54E082A26474F00F631EF /* TestAPIService.swift */; };
+		07B725FA2A2A591A0024C5E8 /* AppleLoginButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07B725F92A2A591A0024C5E8 /* AppleLoginButton.swift */; };
 		FE8486F78C30D594829367F7 /* Pods_Odya_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A7351982B963E0EF9435B0A /* Pods_Odya_iOS.framework */; };
 /* End PBXBuildFile section */
 
@@ -23,8 +25,11 @@
 		071FA5232A20A99F00C7B362 /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
 		071FA5252A20A9A000C7B362 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		071FA5282A20A9A000C7B362 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		073294892A2C9975008E1026 /* UserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaults.swift; sourceTree = "<group>"; };
 		07B54E052A263B5A00F631EF /* TestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestView.swift; sourceTree = "<group>"; };
 		07B54E082A26474F00F631EF /* TestAPIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestAPIService.swift; sourceTree = "<group>"; };
+		07B725F82A2A50280024C5E8 /* Odya-iOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Odya-iOS.entitlements"; sourceTree = "<group>"; };
+		07B725F92A2A591A0024C5E8 /* AppleLoginButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleLoginButton.swift; sourceTree = "<group>"; };
 		5662536329A932018DB3CE02 /* Pods-Odya-iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Odya-iOS.debug.xcconfig"; path = "Target Support Files/Pods-Odya-iOS/Pods-Odya-iOS.debug.xcconfig"; sourceTree = "<group>"; };
 		9A7351982B963E0EF9435B0A /* Pods_Odya_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Odya_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -62,12 +67,14 @@
 		071FA5202A20A99F00C7B362 /* Odya-iOS */ = {
 			isa = PBXGroup;
 			children = (
+				07B725F82A2A50280024C5E8 /* Odya-iOS.entitlements */,
 				071FA52F2A20ADA400C7B362 /* App */,
 				071FA5352A20AE6C00C7B362 /* Core */,
 				071FA5342A20AE6000C7B362 /* Extensions */,
 				071FA5332A20AE5900C7B362 /* Managers */,
 				071FA5252A20A9A000C7B362 /* Assets.xcassets */,
 				071FA5272A20A9A000C7B362 /* Preview Content */,
+				073294892A2C9975008E1026 /* UserDefaults.swift */,
 			);
 			path = "Odya-iOS";
 			sourceTree = "<group>";
@@ -101,6 +108,7 @@
 			isa = PBXGroup;
 			children = (
 				071FA5232A20A99F00C7B362 /* LoginView.swift */,
+				07B725F92A2A591A0024C5E8 /* AppleLoginButton.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -284,6 +292,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				07B54E062A263B5A00F631EF /* TestView.swift in Sources */,
+				07B725FA2A2A591A0024C5E8 /* AppleLoginButton.swift in Sources */,
+				0732948A2A2C9975008E1026 /* UserDefaults.swift in Sources */,
 				071FA5242A20A99F00C7B362 /* LoginView.swift in Sources */,
 				071FA5222A20A99F00C7B362 /* Odya_iOSApp.swift in Sources */,
 				07B54E092A26474F00F631EF /* TestAPIService.swift in Sources */,
@@ -413,6 +423,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = "Odya-iOS/Odya-iOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -445,6 +456,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = "Odya-iOS/Odya-iOS.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Odya-iOS/Preview Content\"";

--- a/Odya-iOS.xcodeproj/project.pbxproj
+++ b/Odya-iOS.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		071FA5202A20A99F00C7B362 /* Odya-iOS */ = {
 			isa = PBXGroup;
 			children = (
+				07DFFC102A2F6EA6006A2FB9 /* Model */,
 				07B725F82A2A50280024C5E8 /* Odya-iOS.entitlements */,
 				071FA52F2A20ADA400C7B362 /* App */,
 				071FA5352A20AE6C00C7B362 /* Core */,
@@ -74,7 +75,6 @@
 				071FA5332A20AE5900C7B362 /* Managers */,
 				071FA5252A20A9A000C7B362 /* Assets.xcassets */,
 				071FA5272A20A9A000C7B362 /* Preview Content */,
-				073294892A2C9975008E1026 /* UserDefaults.swift */,
 			);
 			path = "Odya-iOS";
 			sourceTree = "<group>";
@@ -158,6 +158,14 @@
 				07B54E052A263B5A00F631EF /* TestView.swift */,
 			);
 			path = View;
+			sourceTree = "<group>";
+		};
+		07DFFC102A2F6EA6006A2FB9 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				073294892A2C9975008E1026 /* UserDefaults.swift */,
+			);
+			path = Model;
 			sourceTree = "<group>";
 		};
 		0A92FC640F9E37FB54FEF841 /* Pods */ = {

--- a/Odya-iOS/App/Odya_iOSApp.swift
+++ b/Odya-iOS/App/Odya_iOSApp.swift
@@ -10,36 +10,30 @@ import AuthenticationServices
 
 @main
 struct Odya_iOSApp: App {
-    
+    // TODO: - 생성자 내부의 애플로그인 상태 확인 코드를 Appdelegate의 didFinishLaunchingWithOptions, applicationDidBecomeActive에서 모두 실행하도록 변경
     init() {
+        /// 애플 로그인 상태확인
         let provider = ASAuthorizationAppleIDProvider()
         provider.getCredentialState(forUserID: AppleUserData.userIdentifier) { credentialState, error in
             switch credentialState {
             case .authorized:
-                // 유효한 Apple ID Credential
-                print("DEBUG: Apple ID is authorized")
-                print("""
-                DEBUG: 애플 로그인 정보
-                    userIdentifier: \(AppleUserData.userIdentifier)
-                    familyName: \(AppleUserData.familyName)
-                    givenName: \(AppleUserData.givenName)
-                    email: \(AppleUserData.email)
-                """)
+                // 유효한 Apple ID Credential (인증성공)
+                debugPrint("DEBUG: Apple ID is authorized")
             case .revoked:
-                print("DEBUG: Apple ID is revoked")
+                // 인증만료
+                debugPrint("DEBUG: Apple ID is revoked")
             case .notFound:
-                print("DEBUG: Apple ID is not found")
-
+                debugPrint("DEBUG: Apple ID is not found")
             default:
                 break
             }
         }
     }
     
+    // TODO: - 로그인 로직 수정
     var body: some Scene {
         WindowGroup {
-//            LoginView()
-            AppleLoginButton()
+            LoginView()
         }
     }
 }

--- a/Odya-iOS/App/Odya_iOSApp.swift
+++ b/Odya-iOS/App/Odya_iOSApp.swift
@@ -6,12 +6,40 @@
 //
 
 import SwiftUI
+import AuthenticationServices
 
 @main
 struct Odya_iOSApp: App {
+    
+    init() {
+        let provider = ASAuthorizationAppleIDProvider()
+        provider.getCredentialState(forUserID: AppleUserData.userIdentifier) { credentialState, error in
+            switch credentialState {
+            case .authorized:
+                // 유효한 Apple ID Credential
+                print("DEBUG: Apple ID is authorized")
+                print("""
+                DEBUG: 애플 로그인 정보
+                    userIdentifier: \(AppleUserData.userIdentifier)
+                    familyName: \(AppleUserData.familyName)
+                    givenName: \(AppleUserData.givenName)
+                    email: \(AppleUserData.email)
+                """)
+            case .revoked:
+                print("DEBUG: Apple ID is revoked")
+            case .notFound:
+                print("DEBUG: Apple ID is not found")
+
+            default:
+                break
+            }
+        }
+    }
+    
     var body: some Scene {
         WindowGroup {
-            LoginView()
+//            LoginView()
+            AppleLoginButton()
         }
     }
 }

--- a/Odya-iOS/Core/Login/View/AppleLoginButton.swift
+++ b/Odya-iOS/Core/Login/View/AppleLoginButton.swift
@@ -1,0 +1,75 @@
+//
+//  AppleLoginButton.swift
+//  Odya-iOS
+//
+//  Created by Jade Yoo on 2023/06/03.
+//
+
+import AuthenticationServices
+import SwiftUI
+
+/// 애플 로그인 버튼
+/// - 현재 버튼 디자인: 기본적으로 제공되는 디자인(서체, 색상, Corner radius 모두 기본)
+struct AppleLoginButton: View {
+    var body: some View {
+        SignInWithAppleButton { request in
+            // AppleID 인증을 요청
+            request.requestedScopes = [.fullName, .email]
+        } onCompletion: { result in
+            switch result {
+            case .success(let auth):
+                print("DEBUG: 애플 로그인 성공")
+                
+                switch auth.credential {
+                case let appleIDCredential as ASAuthorizationAppleIDCredential:
+                    let userIdentifier = appleIDCredential.user
+                    let fullName = appleIDCredential.fullName
+                    let email = appleIDCredential.email
+                    
+                    AppleUserData.userIdentifier = userIdentifier
+                    
+                    if let familyName = fullName?.familyName {
+                        AppleUserData.familyName = familyName
+                    }
+                    
+                    if let givenName = fullName?.givenName {
+                        AppleUserData.givenName = givenName
+                    }
+                    
+                    if let email = email {
+                        AppleUserData.email = email
+                    }
+                    
+                    print("""
+                    DEBUG: 로그인 정보
+                        userIdentifier: \(AppleUserData.userIdentifier)
+                        familyName: \(AppleUserData.familyName))
+                        givenName: \(AppleUserData.givenName))
+                        email: \(AppleUserData.email))
+                    """)
+                    // 한번 가입한 후에는 애플아이디 사용중단해도 revoked 되는거라 이름, 이메일안뜸
+                    
+                case let passwordCredential as ASPasswordCredential:
+                    // Sign in using an existing iCloud Keychain credential.
+                    let username = passwordCredential.user
+                    let password = passwordCredential.password
+                    
+                default:
+                    break
+                }
+                
+                
+            case .failure(let error):
+                print("DEBUG: 애플 로그인 실패 with error: \(error.localizedDescription)")
+            }
+        }
+        .frame(height: 50)
+        .padding(.horizontal)
+    }
+}
+
+struct AppleLoginButton_Previews: PreviewProvider {
+    static var previews: some View {
+        AppleLoginButton()
+    }
+}

--- a/Odya-iOS/Core/Login/View/AppleLoginButton.swift
+++ b/Odya-iOS/Core/Login/View/AppleLoginButton.swift
@@ -13,19 +13,19 @@ import SwiftUI
 struct AppleLoginButton: View {
     var body: some View {
         SignInWithAppleButton { request in
-            // AppleID 인증을 요청
+            // AppleID 인증 요청
             request.requestedScopes = [.fullName, .email]
         } onCompletion: { result in
             switch result {
             case .success(let auth):
-                print("DEBUG: 애플 로그인 성공")
+                debugPrint("DEBUG: 애플 로그인 성공")
                 
                 switch auth.credential {
                 case let appleIDCredential as ASAuthorizationAppleIDCredential:
                     let userIdentifier = appleIDCredential.user
                     let fullName = appleIDCredential.fullName
                     let email = appleIDCredential.email
-                    
+                    // UserDefaults에 저장
                     AppleUserData.userIdentifier = userIdentifier
                     
                     if let familyName = fullName?.familyName {
@@ -40,19 +40,12 @@ struct AppleLoginButton: View {
                         AppleUserData.email = email
                     }
                     
-                    print("""
-                    DEBUG: 로그인 정보
-                        userIdentifier: \(AppleUserData.userIdentifier)
-                        familyName: \(AppleUserData.familyName))
-                        givenName: \(AppleUserData.givenName))
-                        email: \(AppleUserData.email))
-                    """)
-                    // 한번 가입한 후에는 애플아이디 사용중단해도 revoked 되는거라 이름, 이메일안뜸
+                    // '최초' 로그인시에만 이름, 이메일 가져오기 가능
                     
                 case let passwordCredential as ASPasswordCredential:
                     // Sign in using an existing iCloud Keychain credential.
-                    let username = passwordCredential.user
-                    let password = passwordCredential.password
+                    _ = passwordCredential.user
+                    _ = passwordCredential.password
                     
                 default:
                     break
@@ -60,11 +53,10 @@ struct AppleLoginButton: View {
                 
                 
             case .failure(let error):
-                print("DEBUG: 애플 로그인 실패 with error: \(error.localizedDescription)")
+                debugPrint("DEBUG: 애플 로그인 실패 with error: \(error.localizedDescription)")
             }
         }
         .frame(height: 50)
-        .padding(.horizontal)
     }
 }
 

--- a/Odya-iOS/Core/Login/View/LoginView.swift
+++ b/Odya-iOS/Core/Login/View/LoginView.swift
@@ -9,11 +9,10 @@ import SwiftUI
 
 struct LoginView: View {
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundColor(.accentColor)
-            Text("Hello, world!")
+        VStack(alignment: .center) {
+            // TODO: - 카카오 로그인 버튼 추가
+            
+            AppleLoginButton()
         }
         .padding()
     }

--- a/Odya-iOS/Model/UserDefaults.swift
+++ b/Odya-iOS/Model/UserDefaults.swift
@@ -27,6 +27,7 @@ struct UserDefault<T> {
     }
 }
 
+/// 애플 유저 데이터 저장
 struct AppleUserData {
     @UserDefault(key: keyEnum_APPLE_USER.userIdentifier.rawValue, defaultValue: "")
     static var userIdentifier: String

--- a/Odya-iOS/Odya-iOS.entitlements
+++ b/Odya-iOS/Odya-iOS.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>

--- a/Odya-iOS/UserDefaults.swift
+++ b/Odya-iOS/UserDefaults.swift
@@ -1,0 +1,49 @@
+//
+//  UserDefaults.swift
+//  Odya-iOS
+//
+//  Created by Jade Yoo on 2023/06/04.
+//
+
+import Foundation
+
+@propertyWrapper
+struct UserDefault<T> {
+    private let key: String
+    private let defaultValue: T
+    
+    init(key: String, defaultValue: T) {
+        self.key = key
+        self.defaultValue = defaultValue
+    }
+    
+    var wrappedValue: T {
+        get {
+            return UserDefaults.standard.object(forKey: key) as? T ?? defaultValue
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: key)
+        }
+    }
+}
+
+struct AppleUserData {
+    @UserDefault(key: keyEnum_APPLE_USER.userIdentifier.rawValue, defaultValue: "")
+    static var userIdentifier: String
+    
+    @UserDefault(key: keyEnum_APPLE_USER.familyName.rawValue, defaultValue: "")
+    static var familyName: String
+    
+    @UserDefault(key: keyEnum_APPLE_USER.givenName.rawValue, defaultValue: "")
+    static var givenName: String
+
+    @UserDefault(key: keyEnum_APPLE_USER.email.rawValue, defaultValue: "")
+    static var email: String
+}
+
+enum keyEnum_APPLE_USER: String {
+    case userIdentifier
+    case familyName
+    case givenName
+    case email
+}


### PR DESCRIPTION
### 개요
애플 로그인 연동
### 변경사항
- 애플 로그인 요청
- 유저 정보 저장
- 앱 시작시 로그인 상태 확인
### 관련 지라 및 위키 링크
[ODYA-25](https://weit.atlassian.net/browse/ODYA-25)
### 리뷰어에게 하고 싶은 말
[앞으로 수정해야 할 것]
- 애플 로그인 상태 확인을 지금 init안에서 확인하고 있는데 요 부분을 카카오 로그인 하시면서 만드신 Appdelegate로 옮기기
- Login 뷰에 카카오로그인 버튼 추가
- App 의 WindowGroup에서 화면 분기

이 내용은 TODO 로 남겨두긴했는데 밍글링 때 잠깐 같이 코드 확인하고 수정해야 할 것 같습니다!
