### PR TITLE
FEAT : ODYA-44 로그인 로직 정리

### DIFF
--- a/Odya-iOS.xcodeproj/project.pbxproj
+++ b/Odya-iOS.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		071FA5292A20A9A000C7B362 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 071FA5282A20A9A000C7B362 /* Preview Assets.xcassets */; };
 		0732948A2A2C9975008E1026 /* UserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 073294892A2C9975008E1026 /* UserDefaults.swift */; };
 		07814B652A3AEAE400F71F95 /* RecentSearchCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07814B642A3AEAE400F71F95 /* RecentSearchCell.swift */; };
+		07A0EC7A2A3F8014002D36B9 /* AppleSignInManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07A0EC792A3F8014002D36B9 /* AppleSignInManager.swift */; };
 		07AF2B142A392AE300D54780 /* GoogleMaps in Frameworks */ = {isa = PBXBuildFile; productRef = 07AF2B132A392AE300D54780 /* GoogleMaps */; };
 		07AF2B162A392AE300D54780 /* GooglePlaces in Frameworks */ = {isa = PBXBuildFile; productRef = 07AF2B152A392AE300D54780 /* GooglePlaces */; };
 		07AF2B192A392F0500D54780 /* LocationSearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07AF2B182A392F0500D54780 /* LocationSearchView.swift */; };
@@ -41,6 +42,7 @@
 		071FA5282A20A9A000C7B362 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		073294892A2C9975008E1026 /* UserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaults.swift; sourceTree = "<group>"; };
 		07814B642A3AEAE400F71F95 /* RecentSearchCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentSearchCell.swift; sourceTree = "<group>"; };
+		07A0EC792A3F8014002D36B9 /* AppleSignInManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleSignInManager.swift; sourceTree = "<group>"; };
 		07AF2B182A392F0500D54780 /* LocationSearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationSearchView.swift; sourceTree = "<group>"; };
 		07AF2B1A2A392F1600D54780 /* LocationSearchActivationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationSearchActivationView.swift; sourceTree = "<group>"; };
 		07AF2B1C2A392F7800D54780 /* LocationSearchResultCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationSearchResultCell.swift; sourceTree = "<group>"; };
@@ -148,6 +150,7 @@
 		071FA5332A20AE5900C7B362 /* Managers */ = {
 			isa = PBXGroup;
 			children = (
+				07A0EC792A3F8014002D36B9 /* AppleSignInManager.swift */,
 			);
 			path = Managers;
 			sourceTree = "<group>";
@@ -326,6 +329,7 @@
 				3E36EC732A2B596C006008E5 /* MainView.swift in Sources */,
 				071FA5242A20A99F00C7B362 /* LoginView.swift in Sources */,
 				071FA5222A20A99F00C7B362 /* Odya_iOSApp.swift in Sources */,
+				07A0EC7A2A3F8014002D36B9 /* AppleSignInManager.swift in Sources */,
 				3E0589012A276E84005C29D9 /* AppDelegate.swift in Sources */,
 				3E0588FD2A276E64005C29D9 /* KakaoLoginView.swift in Sources */,
 				3E0589032A276E8C005C29D9 /* SceneDelegate.swift in Sources */,
@@ -473,6 +477,7 @@
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 7V2ZG69KPK;
 				ENABLE_PREVIEWS = YES;
+				EXCLUDED_ARCHS = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Odya-iOS/Info.plist";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -509,6 +514,7 @@
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 7V2ZG69KPK;
 				ENABLE_PREVIEWS = YES;
+				EXCLUDED_ARCHS = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Odya-iOS/Info.plist";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;

--- a/Odya-iOS.xcodeproj/project.pbxproj
+++ b/Odya-iOS.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		0732948A2A2C9975008E1026 /* UserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 073294892A2C9975008E1026 /* UserDefaults.swift */; };
 		07814B652A3AEAE400F71F95 /* RecentSearchCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07814B642A3AEAE400F71F95 /* RecentSearchCell.swift */; };
 		07A0EC7A2A3F8014002D36B9 /* AppleSignInManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07A0EC792A3F8014002D36B9 /* AppleSignInManager.swift */; };
+		07A0EC802A3F9333002D36B9 /* RootTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07A0EC7F2A3F9333002D36B9 /* RootTabView.swift */; };
+		07A0EC832A3F95DC002D36B9 /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07A0EC822A3F95DC002D36B9 /* ProfileView.swift */; };
 		07AF2B142A392AE300D54780 /* GoogleMaps in Frameworks */ = {isa = PBXBuildFile; productRef = 07AF2B132A392AE300D54780 /* GoogleMaps */; };
 		07AF2B162A392AE300D54780 /* GooglePlaces in Frameworks */ = {isa = PBXBuildFile; productRef = 07AF2B152A392AE300D54780 /* GooglePlaces */; };
 		07AF2B192A392F0500D54780 /* LocationSearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07AF2B182A392F0500D54780 /* LocationSearchView.swift */; };
@@ -43,6 +45,8 @@
 		073294892A2C9975008E1026 /* UserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaults.swift; sourceTree = "<group>"; };
 		07814B642A3AEAE400F71F95 /* RecentSearchCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentSearchCell.swift; sourceTree = "<group>"; };
 		07A0EC792A3F8014002D36B9 /* AppleSignInManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleSignInManager.swift; sourceTree = "<group>"; };
+		07A0EC7F2A3F9333002D36B9 /* RootTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootTabView.swift; sourceTree = "<group>"; };
+		07A0EC822A3F95DC002D36B9 /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
 		07AF2B182A392F0500D54780 /* LocationSearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationSearchView.swift; sourceTree = "<group>"; };
 		07AF2B1A2A392F1600D54780 /* LocationSearchActivationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationSearchActivationView.swift; sourceTree = "<group>"; };
 		07AF2B1C2A392F7800D54780 /* LocationSearchResultCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationSearchResultCell.swift; sourceTree = "<group>"; };
@@ -165,12 +169,22 @@
 		071FA5352A20AE6C00C7B362 /* Core */ = {
 			isa = PBXGroup;
 			children = (
+				07A0EC7F2A3F9333002D36B9 /* RootTabView.swift */,
+				3E36EC722A2B596C006008E5 /* MainView.swift */,
+				07A0EC812A3F95BC002D36B9 /* Settings */,
 				07B54E032A263B2700F631EF /* API_Test */,
 				071FA5302A20ADAC00C7B362 /* Login */,
-				3E36EC722A2B596C006008E5 /* MainView.swift */,
 				07AF2B172A392EEE00D54780 /* LocationSearch */,
 			);
 			path = Core;
+			sourceTree = "<group>";
+		};
+		07A0EC812A3F95BC002D36B9 /* Settings */ = {
+			isa = PBXGroup;
+			children = (
+				07A0EC822A3F95DC002D36B9 /* ProfileView.swift */,
+			);
+			path = Settings;
 			sourceTree = "<group>";
 		};
 		07AF2B172A392EEE00D54780 /* LocationSearch */ = {
@@ -320,6 +334,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				07AF2B1D2A392F7800D54780 /* LocationSearchResultCell.swift in Sources */,
+				07A0EC832A3F95DC002D36B9 /* ProfileView.swift in Sources */,
 				07814B652A3AEAE400F71F95 /* RecentSearchCell.swift in Sources */,
 				07B54E062A263B5A00F631EF /* TestView.swift in Sources */,
 				07B725FA2A2A591A0024C5E8 /* AppleLoginButton.swift in Sources */,
@@ -327,6 +342,7 @@
 				0732948A2A2C9975008E1026 /* UserDefaults.swift in Sources */,
 				3E0588FF2A276E76005C29D9 /* KakaoAuthViewModel.swift in Sources */,
 				3E36EC732A2B596C006008E5 /* MainView.swift in Sources */,
+				07A0EC802A3F9333002D36B9 /* RootTabView.swift in Sources */,
 				071FA5242A20A99F00C7B362 /* LoginView.swift in Sources */,
 				071FA5222A20A99F00C7B362 /* Odya_iOSApp.swift in Sources */,
 				07A0EC7A2A3F8014002D36B9 /* AppleSignInManager.swift in Sources */,

--- a/Odya-iOS/App/AppDelegate.swift
+++ b/Odya-iOS/App/AppDelegate.swift
@@ -5,7 +5,6 @@
 //  Created by Heeoh Son on 2023/05/31.
 //
 
-import Foundation
 import UIKit
 import GooglePlaces
 import KakaoSDKCommon
@@ -20,9 +19,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         GMSPlacesClient.provideAPIKey(gmsApiKey)
         // kakao SDK 초기화
         KakaoSDK.initSDK(appKey: kakaoApiKey as! String)
+        // Apple Sign In 상태 확인, 유효 여부 저장
+        Task {
+            AppleUserData.isValid = await AppleSignInManager.shared.checkIfLoginWithApple()
+        }
+        
         return true
     }
-    
     
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
         if (AuthApi.isKakaoTalkLoginUrl(url)) {
@@ -42,4 +45,3 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return sceneConfiguration
     }
 }
-

--- a/Odya-iOS/App/Odya_iOSApp.swift
+++ b/Odya-iOS/App/Odya_iOSApp.swift
@@ -5,13 +5,12 @@
 //  Created by Jade Yoo on 2023/05/26.
 //
 
-import Foundation
 import SwiftUI
-import AuthenticationServices
 import KakaoSDKUser
 
 @main
 struct Odya_iOSApp: App {
+    
     // MARK: PROPERTIES
     
     // with AppDelegate.swift
@@ -19,39 +18,19 @@ struct Odya_iOSApp: App {
     
     /// 카카오 자동로그인 확인을 위한 토큰
     @AppStorage("accessToken") var kakaoAccessToken: String?
-  
-    // TODO: - 생성자 내부의 애플로그인 상태 확인 코드를 Appdelegate의 didFinishLaunchingWithOptions, applicationDidBecomeActive에서 모두 실행하도록 변경
-    init() {
-        /// 애플 로그인 상태확인
-        let provider = ASAuthorizationAppleIDProvider()
-        provider.getCredentialState(forUserID: AppleUserData.userIdentifier) { credentialState, error in
-            switch credentialState {
-            case .authorized:
-                // 유효한 Apple ID Credential (인증성공)
-                debugPrint("DEBUG: Apple ID is authorized")
-            case .revoked:
-                // 인증만료
-                debugPrint("DEBUG: Apple ID is revoked")
-            case .notFound:
-                debugPrint("DEBUG: Apple ID is not found")
-            default:
-                break
-            }
-        }
-    }
     
-    // TODO: - 로그인 로직 수정
- 
+    /// 애플 자동로그인 확인을 위한 인증 유효 여부
+    @AppStorage("isAppleSignInValid") var isAppleSignInValid: Bool = AppleUserData.isValid
+
     // MARK: BODY
 
     var body: some Scene {
         WindowGroup {
-            if kakaoAccessToken != nil {
+            if kakaoAccessToken != nil || isAppleSignInValid {
                 MainView()
             } else {
-                KakaoLoginView()
+                LoginView()
             }
-            // LoginView()
         }
     }
     

--- a/Odya-iOS/App/Odya_iOSApp.swift
+++ b/Odya-iOS/App/Odya_iOSApp.swift
@@ -27,7 +27,7 @@ struct Odya_iOSApp: App {
     var body: some Scene {
         WindowGroup {
             if kakaoAccessToken != nil || isAppleSignInValid {
-                MainView()
+                RootTabView()
             } else {
                 LoginView()
             }

--- a/Odya-iOS/App/SceneDelegate.swift
+++ b/Odya-iOS/App/SceneDelegate.swift
@@ -5,17 +5,30 @@
 //  Created by Heeoh Son on 2023/05/31.
 //
 
-import Foundation
 import UIKit
+import SwiftUI
 import KakaoSDKAuth
 
-
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+    @AppStorage("accessToken") var kakaoAccessToken: String?
+    @AppStorage("isAppleSignInValid") var isAppleSignInValid: Bool = AppleUserData.isValid
     
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
         if let url = URLContexts.first?.url {
             if (AuthApi.isKakaoTalkLoginUrl(url)) {
                 _ = AuthController.handleOpenUrl(url: url)
+            }
+        }
+    }
+    
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        // 애플로그인 후 실행 중 애플아이디 사용 중단한 경우
+        if kakaoAccessToken == nil {
+            Task {
+                if await AppleSignInManager.shared.checkIfLoginWithApple() == false {
+                    AppleUserData.isValid = false
+                    isAppleSignInValid = false
+                }
             }
         }
     }

--- a/Odya-iOS/Core/Login/View/AppleLoginButton.swift
+++ b/Odya-iOS/Core/Login/View/AppleLoginButton.swift
@@ -10,6 +10,8 @@ import SwiftUI
 
 /// 애플 로그인 버튼
 struct AppleLoginButton: View {
+    @AppStorage("isAppleSignInValid") var isAppleSignInValid: Bool = AppleUserData.isValid
+
     var body: some View {
         SignInWithAppleButton { request in
             // AppleID 인증 요청
@@ -40,6 +42,8 @@ struct AppleLoginButton: View {
                     }
                     
                     // '최초' 로그인시에만 이름, 이메일 가져오기 가능
+                    AppleUserData.isValid = true
+                    isAppleSignInValid = true
                     
                 case let passwordCredential as ASPasswordCredential:
                     // Sign in using an existing iCloud Keychain credential.

--- a/Odya-iOS/Core/Login/View/AppleLoginButton.swift
+++ b/Odya-iOS/Core/Login/View/AppleLoginButton.swift
@@ -9,7 +9,6 @@ import AuthenticationServices
 import SwiftUI
 
 /// 애플 로그인 버튼
-/// - 현재 버튼 디자인: 기본적으로 제공되는 디자인(서체, 색상, Corner radius 모두 기본)
 struct AppleLoginButton: View {
     var body: some View {
         SignInWithAppleButton { request in
@@ -51,12 +50,12 @@ struct AppleLoginButton: View {
                     break
                 }
                 
-                
             case .failure(let error):
                 debugPrint("DEBUG: 애플 로그인 실패 with error: \(error.localizedDescription)")
             }
         }
-        .frame(height: 50)
+        .frame(height: 44)
+        .signInWithAppleButtonStyle(.white)
     }
 }
 

--- a/Odya-iOS/Core/Login/View/KakaoLoginView.swift
+++ b/Odya-iOS/Core/Login/View/KakaoLoginView.swift
@@ -26,7 +26,7 @@ struct KakaoLoginView: View {
                         .foregroundColor(.black)
                         .frame(maxWidth: .infinity)
                 }
-                .frame(width: 300, height: 45)
+                .frame(width: 300, height: 44)
                 .padding(.horizontal, 10)
                 .background(.yellow)
                 .cornerRadius(4)

--- a/Odya-iOS/Core/Login/View/LoginView.swift
+++ b/Odya-iOS/Core/Login/View/LoginView.swift
@@ -10,8 +10,8 @@ import SwiftUI
 struct LoginView: View {
     var body: some View {
         VStack(alignment: .center) {
-            // TODO: - 카카오 로그인 버튼 추가
-            
+            Spacer()
+            KakaoLoginView()
             AppleLoginButton()
         }
         .padding()

--- a/Odya-iOS/Core/RootTabView.swift
+++ b/Odya-iOS/Core/RootTabView.swift
@@ -1,0 +1,32 @@
+//
+//  RootTabView.swift
+//  Odya-iOS
+//
+//  Created by Jade Yoo on 2023/06/19.
+//
+
+import SwiftUI
+
+struct RootTabView: View {
+    var body: some View {
+        TabView {
+            // 메인 홈
+            MainView()
+                .tabItem {
+                    Image(systemName: "house")
+                }
+            
+            // 내 정보
+            ProfileView()
+                .tabItem {
+                    Image(systemName: "person")
+                }
+        }
+    }
+}
+
+struct RootTabView_Previews: PreviewProvider {
+    static var previews: some View {
+        RootTabView()
+    }
+}

--- a/Odya-iOS/Core/Settings/ProfileView.swift
+++ b/Odya-iOS/Core/Settings/ProfileView.swift
@@ -1,0 +1,20 @@
+//
+//  ProfileView.swift
+//  Odya-iOS
+//
+//  Created by Jade Yoo on 2023/06/19.
+//
+
+import SwiftUI
+
+struct ProfileView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+struct SettingView_Previews: PreviewProvider {
+    static var previews: some View {
+        ProfileView()
+    }
+}

--- a/Odya-iOS/Managers/AppleSignInManager.swift
+++ b/Odya-iOS/Managers/AppleSignInManager.swift
@@ -1,0 +1,44 @@
+//
+//  AppleSignInManager.swift
+//  Odya-iOS
+//
+//  Created by Jade Yoo on 2023/06/19.
+//
+
+import AuthenticationServices
+import UIKit
+import SwiftUI
+
+final class AppleSignInManager {
+    static let shared = AppleSignInManager()
+    
+    private init() { }
+    
+    // MARK: - Helpers
+    
+    /// 애플 로그인 상태확인
+    func checkIfLoginWithApple() async -> Bool {
+        let provider = ASAuthorizationAppleIDProvider()
+        do {
+            let state = try await provider.credentialState(forUserID: AppleUserData.userIdentifier)
+            switch state {
+            case .authorized:
+                // 유효한 Apple ID Credential (인증성공)
+                debugPrint("DEBUG: Apple ID is authorized")
+                return true
+            case .revoked:
+                // 인증만료
+                debugPrint("DEBUG: Apple ID is revoked")
+            case .notFound:
+                debugPrint("DEBUG: Apple ID is not found")
+            default:
+                break
+            }
+        } catch let error {
+            debugPrint(error.localizedDescription)
+        }
+        
+        return false
+    }
+    
+}

--- a/Odya-iOS/Model/UserDefaults.swift
+++ b/Odya-iOS/Model/UserDefaults.swift
@@ -29,6 +29,9 @@ struct UserDefault<T> {
 
 /// 애플 유저 데이터 저장
 struct AppleUserData {
+    @UserDefault(key: keyEnum_APPLE_USER.isValid.rawValue, defaultValue: false)
+    static var isValid: Bool
+    
     @UserDefault(key: keyEnum_APPLE_USER.userIdentifier.rawValue, defaultValue: "")
     static var userIdentifier: String
     
@@ -49,6 +52,7 @@ struct SearchData {
 }
 
 enum keyEnum_APPLE_USER: String {
+    case isValid
     case userIdentifier
     case familyName
     case givenName


### PR DESCRIPTION
### 개요
로그인 로직 정리

### 변경사항
- 카카오, 애플 중 하나의 토큰 or 인증 확인 받으면 메인뷰로 이동
- AppDelegate 와 SceneDelegate 에서 각각 앱을 실행할때, 활성상태가 되었을때 애플로그인 인증이 유효한지 검사합니다.
- 메인 뷰와 앞으로 추가될 뷰들이 담길 RootTabView 추가

### 관련 지라 및 위키 링크
[ODYA-44](https://weit.atlassian.net/browse/ODYA-44)

### 리뷰어에게 하고 싶은 말
ProfileView에 아직 아무것도 없습니당
메인 홈에 지도 올리면서 로그아웃 버튼을 프로필뷰 쪽으로 이사시킬 예정