### PR TITLE
feat: firebase sign in, apple and kakao both

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ Podfile.lock
 
 #config
 Odya-iOS/*.xcconfig
+
+# property list
+Odya-iOS/GoogleService-Info.plist

--- a/Odya-iOS.xcodeproj/project.pbxproj
+++ b/Odya-iOS.xcodeproj/project.pbxproj
@@ -41,6 +41,9 @@
 		3E800EC12A3E1561001EA4C4 /* WebpTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E800EC02A3E1561001EA4C4 /* WebpTestView.swift */; };
 		3E800EC32A3E15D9001EA4C4 /* ImageGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E800EC22A3E15D9001EA4C4 /* ImageGridView.swift */; };
 		3E800EC52A3E16D4001EA4C4 /* PhotoPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E800EC42A3E16D4001EA4C4 /* PhotoPickerView.swift */; };
+		3EBEC3912A6B1C2600998EC6 /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 3EBEC3902A6B1C2600998EC6 /* FirebaseAuth */; };
+		3EBEC3932A6B1D7F00998EC6 /* AppleAuthViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EBEC3922A6B1D7F00998EC6 /* AppleAuthViewModel.swift */; };
+		3EBEC39E2A6B293100998EC6 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3EBEC39D2A6B293100998EC6 /* GoogleService-Info.plist */; };
 		3EF549862A419100006562F8 /* ColorStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EF549852A419100006562F8 /* ColorStyles.swift */; };
 		3EF549912A4200EA006562F8 /* NotoSansKR-Medium.otf in Resources */ = {isa = PBXBuildFile; fileRef = 3EF5498A2A4200E9006562F8 /* NotoSansKR-Medium.otf */; };
 		3EF549922A4200EA006562F8 /* NotoSansKR-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = 3EF5498B2A4200E9006562F8 /* NotoSansKR-Regular.otf */; };
@@ -59,7 +62,6 @@
 		3EF549B82A46ED30006562F8 /* 한국기계연구원_Light.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 3EF549B62A46ED30006562F8 /* 한국기계연구원_Light.ttf */; };
 		3EF549BA2A482B1D006562F8 /* UserAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EF549B92A482B1D006562F8 /* UserAuth.swift */; };
 		3EF549BE2A485EDE006562F8 /* SignUpView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EF549BD2A485EDE006562F8 /* SignUpView.swift */; };
-		3EF549C12A497DAE006562F8 /* NicknameValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EF549C02A497DAD006562F8 /* NicknameValidator.swift */; };
 		3EF549FD2A5BE92F006562F8 /* ApiLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EF549FC2A5BE92F006562F8 /* ApiLogger.swift */; };
 		3EF549FF2A5BE938006562F8 /* ApiClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EF549FE2A5BE938006562F8 /* ApiClient.swift */; };
 		3EF54A012A5BE96D006562F8 /* BaseInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EF54A002A5BE96D006562F8 /* BaseInterceptor.swift */; };
@@ -105,6 +107,8 @@
 		3E800EC02A3E1561001EA4C4 /* WebpTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebpTestView.swift; sourceTree = "<group>"; };
 		3E800EC22A3E15D9001EA4C4 /* ImageGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageGridView.swift; sourceTree = "<group>"; };
 		3E800EC42A3E16D4001EA4C4 /* PhotoPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoPickerView.swift; sourceTree = "<group>"; };
+		3EBEC3922A6B1D7F00998EC6 /* AppleAuthViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleAuthViewModel.swift; sourceTree = "<group>"; };
+		3EBEC39D2A6B293100998EC6 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../Downloads/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		3EF549852A419100006562F8 /* ColorStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorStyles.swift; sourceTree = "<group>"; };
 		3EF5498A2A4200E9006562F8 /* NotoSansKR-Medium.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "NotoSansKR-Medium.otf"; sourceTree = "<group>"; };
 		3EF5498B2A4200E9006562F8 /* NotoSansKR-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "NotoSansKR-Regular.otf"; sourceTree = "<group>"; };
@@ -123,7 +127,6 @@
 		3EF549B62A46ED30006562F8 /* 한국기계연구원_Light.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "한국기계연구원_Light.ttf"; sourceTree = "<group>"; };
 		3EF549B92A482B1D006562F8 /* UserAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAuth.swift; sourceTree = "<group>"; };
 		3EF549BD2A485EDE006562F8 /* SignUpView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpView.swift; sourceTree = "<group>"; };
-		3EF549C02A497DAD006562F8 /* NicknameValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameValidator.swift; sourceTree = "<group>"; };
 		3EF549FC2A5BE92F006562F8 /* ApiLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApiLogger.swift; sourceTree = "<group>"; };
 		3EF549FE2A5BE938006562F8 /* ApiClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApiClient.swift; sourceTree = "<group>"; };
 		3EF54A002A5BE96D006562F8 /* BaseInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseInterceptor.swift; sourceTree = "<group>"; };
@@ -146,6 +149,7 @@
 				3E3EC3B32A388ADE002BF519 /* webp in Frameworks */,
 				3E3EC3AD2A388AA5002BF519 /* Alamofire in Frameworks */,
 				07AF2B162A392AE300D54780 /* GooglePlaces in Frameworks */,
+				3EBEC3912A6B1C2600998EC6 /* FirebaseAuth in Frameworks */,
 				07AF2B142A392AE300D54780 /* GoogleMaps in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -185,6 +189,7 @@
 				07DFFC102A2F6EA6006A2FB9 /* Model */,
 				07B725F82A2A50280024C5E8 /* Odya-iOS.entitlements */,
 				3E0589042A276EAD005C29D9 /* Info.plist */,
+				3EBEC39D2A6B293100998EC6 /* GoogleService-Info.plist */,
 				3E0589052A277063005C29D9 /* Config.xcconfig */,
 				071FA52F2A20ADA400C7B362 /* App */,
 				071FA5352A20AE6C00C7B362 /* Core */,
@@ -332,6 +337,7 @@
 			children = (
 				3E0588FE2A276E76005C29D9 /* KakaoAuthViewModel.swift */,
 				3EF54A0E2A5BF9BD006562F8 /* AuthViewModel.swift */,
+				3EBEC3922A6B1D7F00998EC6 /* AppleAuthViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -466,6 +472,7 @@
 				3E3EC3B52A388B55002BF519 /* KakaoSDK */,
 				07AF2B132A392AE300D54780 /* GoogleMaps */,
 				07AF2B152A392AE300D54780 /* GooglePlaces */,
+				3EBEC3902A6B1C2600998EC6 /* FirebaseAuth */,
 			);
 			productName = "Odya-iOS";
 			productReference = 071FA51E2A20A99F00C7B362 /* Odya-iOS.app */;
@@ -501,6 +508,7 @@
 				3E3EC3B12A388ADE002BF519 /* XCRemoteSwiftPackageReference "webp.swift" */,
 				3E3EC3B42A388B55002BF519 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */,
 				07AF2B122A392AE300D54780 /* XCRemoteSwiftPackageReference "GoogleMaps-SP" */,
+				3EBEC38F2A6B1C2600998EC6 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 			);
 			productRefGroup = 071FA51F2A20A99F00C7B362 /* Products */;
 			projectDirPath = "";
@@ -521,6 +529,7 @@
 				3EF549942A4200EB006562F8 /* NotoSansKR-Thin.otf in Resources */,
 				3EF549962A4200EB006562F8 /* NotoSansKR-Light.otf in Resources */,
 				3EF549B72A46ED30006562F8 /* 한국기계연구원_bold.ttf in Resources */,
+				3EBEC39E2A6B293100998EC6 /* GoogleService-Info.plist in Resources */,
 				3EF549912A4200EA006562F8 /* NotoSansKR-Medium.otf in Resources */,
 				3EF549B82A46ED30006562F8 /* 한국기계연구원_Light.ttf in Resources */,
 				071FA5292A20A9A000C7B362 /* Preview Assets.xcassets in Resources */,
@@ -539,6 +548,7 @@
 			files = (
 				07AF2B1D2A392F7800D54780 /* LocationSearchResultCell.swift in Sources */,
 				0707A1C42A45A37100AE6E4D /* HomeView.swift in Sources */,
+				3EBEC3932A6B1D7F00998EC6 /* AppleAuthViewModel.swift in Sources */,
 				3EF549BE2A485EDE006562F8 /* SignUpView.swift in Sources */,
 				07A0EC832A3F95DC002D36B9 /* ProfileView.swift in Sources */,
 				07814B652A3AEAE400F71F95 /* RecentSearchCell.swift in Sources */,
@@ -726,11 +736,16 @@
 				EXCLUDED_ARCHS = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Odya-iOS/Info.plist";
+				INFOPLIST_KEY_LSApplicationCategoryType = "";
+				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "사용자의 위치 정보를 사용합니다.";
+				INFOPLIST_KEY_NSLocationAlwaysUsageDescription = "사용자의 위치 정보를 사용합니다.";
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "사용자의 위치 정보를 사용합니다.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UIUserInterfaceStyle = Dark;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -763,11 +778,16 @@
 				EXCLUDED_ARCHS = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Odya-iOS/Info.plist";
+				INFOPLIST_KEY_LSApplicationCategoryType = "";
+				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "사용자의 위치 정보를 사용합니다.";
+				INFOPLIST_KEY_NSLocationAlwaysUsageDescription = "사용자의 위치 정보를 사용합니다.";
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "사용자의 위치 정보를 사용합니다.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UIUserInterfaceStyle = Dark;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -847,6 +867,14 @@
 				minimumVersion = 2.0.0;
 			};
 		};
+		3EBEC38F2A6B1C2600998EC6 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/firebase/firebase-ios-sdk.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 10.0.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -879,6 +907,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 3E3EC3B42A388B55002BF519 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
 			productName = KakaoSDK;
+		};
+		3EBEC3902A6B1C2600998EC6 /* FirebaseAuth */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3EBEC38F2A6B1C2600998EC6 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAuth;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Odya-iOS/App/AppDelegate.swift
+++ b/Odya-iOS/App/AppDelegate.swift
@@ -10,6 +10,7 @@ import GoogleMaps
 import GooglePlaces
 import KakaoSDKCommon
 import KakaoSDKAuth
+import FirebaseCore
 
 class AppDelegate: UIResponder, UIApplicationDelegate {
     
@@ -20,6 +21,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let gmsApiKey = String(describing: Bundle.main.infoDictionary?["GOOGLE_MAPS_API_KEY"] ?? "")
         GMSPlacesClient.provideAPIKey(gmsApiKey)
         GMSServices.provideAPIKey(gmsApiKey)
+        
+        // firebase SDK 초기화
+        FirebaseApp.configure()
         
         // kakao SDK 초기화
         KakaoSDK.initSDK(appKey: kakaoApiKey as! String)

--- a/Odya-iOS/Core/Login/View/AppleLoginButton.swift
+++ b/Odya-iOS/Core/Login/View/AppleLoginButton.swift
@@ -11,77 +11,14 @@ import SwiftUI
 /// 애플 로그인 버튼
 struct AppleLoginButton: View {
     @AppStorage("isAppleSignInValid") var isAppleSignInValid: Bool = AppleUserData.isValid
-
-    @StateObject var AuthApi = AuthViewModel()
+    
+    @StateObject var AppleAuthVM = AppleAuthViewModel()
     
     var body: some View {
         SignInWithAppleButton { request in
-            // AppleID 인증 요청
-            request.requestedScopes = [.fullName, .email]
+            AppleAuthVM.handleSignInWithAppleRequest(request)
         } onCompletion: { result in
-            switch result {
-            case .success(let auth):
-                debugPrint("DEBUG: 애플 로그인 성공")
-                
-                switch auth.credential {
-                case let appleIDCredential as ASAuthorizationAppleIDCredential:
-                    let userIdentifier = appleIDCredential.user
-                    let fullName = appleIDCredential.fullName
-                    let email = appleIDCredential.email
-                    
-                    if let appleIDToken = appleIDCredential.identityToken,
-                       let idTokenString = String(data: appleIDToken, encoding: .utf8) {
-                        
-                        // server login
-                        AuthApi.appleLogin(idToken: idTokenString, userName: userIdentifier) { apiResult in
-                            switch apiResult {
-                            case .success:
-                                // UserDefaults에 저장
-                                AppleUserData.userIdentifier = userIdentifier
-                                
-                                if let familyName = fullName?.familyName {
-                                    AppleUserData.familyName = familyName
-                                }
-                                if let givenName = fullName?.givenName {
-                                    AppleUserData.givenName = givenName
-                                }
-                                if let email = email {
-                                    AppleUserData.email = email
-                                }
-                                
-                                // '최초' 로그인시에만 이름, 이메일 가져오기 가능
-                                AppleUserData.isValid = true
-                                isAppleSignInValid = true
-                            case .unauthorized:
-                                if let familyName = fullName?.familyName,
-                                   let givenName = fullName?.givenName
-                                {
-                                    print("SignUp \(familyName) \(givenName)")
-                                } else {
-                                    print("Error: need to register but no name")
-                                }
-                                // SignUpView
-                            case .error(let errorMessage):
-                                print("Error: \(errorMessage)")
-                            }
-                        }
-                    }
-                    
-                    
-                case let passwordCredential as ASPasswordCredential:
-                    // Sign in using an existing iCloud Keychain credential.
-                    _ = passwordCredential.user
-                    _ = passwordCredential.password
-                    
-                default:
-                    break
-                    
-                    
-                    
-                }
-            case .failure(let error):
-                debugPrint("DEBUG: 애플 로그인 실패 with error: \(error.localizedDescription)")
-            }
+            AppleAuthVM.handleSignInWithAppleCompletion(result)
         }
         .frame(height: 44)
         .signInWithAppleButtonStyle(.white)

--- a/Odya-iOS/Core/Login/View/SignUpView.swift
+++ b/Odya-iOS/Core/Login/View/SignUpView.swift
@@ -69,6 +69,7 @@ struct SignUpView: View {
                             print("SignUp Button")
                             if isSuccess == true {
                                 print("success")
+                                // TODO: kakao server login 다시 호출 & 파이어베이스 연동
                             } else if let message = errorMessage {
                                 print(message)
                             } else {

--- a/Odya-iOS/Core/Login/ViewModel/AppleAuthViewModel.swift
+++ b/Odya-iOS/Core/Login/ViewModel/AppleAuthViewModel.swift
@@ -1,0 +1,141 @@
+//
+//  AppleAuthViewModel.swift
+//  Odya-iOS
+//
+//  Created by Heeoh Son on 2023/07/22.
+//
+
+import SwiftUI
+import Firebase
+import CryptoKit
+import AuthenticationServices
+
+class AppleAuthViewModel: ObservableObject {
+    
+    @Published var AuthApi = AuthViewModel()
+    
+    /// 토큰
+    @AppStorage("WeITAuthToken") var idToken: String?
+    
+    var currentNonce: String? = nil
+    
+    func handleSignInWithAppleRequest(_ request: ASAuthorizationAppleIDRequest) {
+        request.requestedScopes = [.fullName, .email]
+        
+        /// 로그인 요청마다 임의의 문자열인 'nonce'가 생성되며, 이 nonce는 앱의 인증 요청에 대한 응답으로 ID 토큰이 명시적으로 부여되었는지 확인하는 데 사용됩니다. 재전송 공격을 방지하려면 이 단계가 필요합니다.
+        /// 로그인 요청과 함께 nonce의 SHA256 해시를 전송하면 Apple은 이에 대한 응답으로 원래의 값을 전달합니다. Firebase는 원래의 nonce를 해싱하고 Apple에서 전달한 값과 비교하여 응답을 검증합니다.
+        let nonce = randomNonceString()
+        currentNonce = nonce
+        request.nonce = sha256(nonce)
+    }
+    
+    /// 애플 소셜 로그인 성공 시 실행되는 handler
+    /// 애플 소셜 로그인 -> 파이어베이스 로그인/연동 -> 파이어베이서 토큰을 이용해 서버 로그인
+    func handleSignInWithAppleCompletion(_ appleSigninResult: Result<ASAuthorization, Error>) {
+        if case .failure(let failure) = appleSigninResult {
+            debugPrint(failure.localizedDescription)
+        } else if case .success(let success) = appleSigninResult {
+            // print("애플 소셜 로그인 성공")
+            if let appleIDCredential = success.credential as? ASAuthorizationAppleIDCredential {
+                
+                // firebase login
+                guard let appleIDToken = appleIDCredential.identityToken else {
+                    print("Error in AppleAuthViewModel handleSignInWithAppleCompletion(): Unable to fetch identity token.")
+                    return
+                }
+                guard let idTokenString = String(data: appleIDToken, encoding: .utf8) else {
+                    print("Error in AppleAuthViewModel handleSignInWithAppleCompletion(): Unable to serialise token string from data: \(appleIDToken.debugDescription)")
+                    return
+                }
+                
+                guard let nonce = currentNonce else {
+                    fatalError("Error in AppleAuthViewModel handleSignInWithAppleCompletion(): Invalid state: a login callback was received, but no login request was sent.")
+                    return
+                }
+                
+                let firebaseCredential = OAuthProvider.credential(withProviderID: "apple.com",
+                                                                  idToken: idTokenString,
+                                                                  rawNonce: nonce)
+                
+                Auth.auth().signIn(with: firebaseCredential) { firebaseSignInResult, error in
+                    if let err = error {
+                        print(err.localizedDescription)
+                    }
+                    
+                    // print("firebase 로그인 완료")
+                    
+                    // idToken 유효성 확인
+                    let currentUser = Auth.auth().currentUser
+                    currentUser?.getIDTokenForcingRefresh(true) { idToken, error in
+                        if let error = error {
+                            print("Error in AppleAuthViewModel handleSignInWithAppleCompletion(): \(error.localizedDescription)")
+                            return
+                        }
+                        
+                        // idToken을 이용해 서버 로그인
+                        if let idToken = idToken {
+                            self.doServerLogin(idToken: idToken, userName: "test")
+                        } else {
+                            print("Error in AppleAuthViewModel handleSignInWithAppleCompletion(): Invalid Token")
+                            return
+                        }
+                    }
+                    
+                    // user info
+                    // let userIdentifier = appleIDCredential.user
+                    // let fullName = appleIDCredential.fullName
+                    // let email = appleIDCredential.email
+                }
+            }
+        }
+    }
+    
+    /// 서버 로그인 api 호출
+    private func doServerLogin(idToken: String, userName: String) {
+        AuthApi.appleLogin(idToken: idToken, userName: userName) { apiResult in
+            switch apiResult {
+            case .success:
+                print("apple login complete")
+                self.idToken = idToken
+            case .unauthorized:
+                print("Error in AppleAuthViewModel doServerLogin(): valid token but required to register")
+                // TODO: 회원가입에 필요한 유저정보 가져오기
+                // TODO: SignUpView 연결하기
+            case .error(let errorMessage):
+                print("Error in AppleAuthViewModel doServerLogin(): \(errorMessage)")
+            }
+        }
+    }
+    
+    private func randomNonceString(length: Int = 32) -> String {
+        precondition(length > 0)
+        var randomBytes = [UInt8](repeating: 0, count: length)
+        let errorCode = SecRandomCopyBytes(kSecRandomDefault, randomBytes.count, &randomBytes)
+        if errorCode != errSecSuccess {
+            fatalError(
+                "Unable to generate nonce. SecRandomCopyBytes failed with OSStatus \(errorCode)"
+            )
+        }
+        
+        let charset: [Character] =
+        Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
+        
+        let nonce = randomBytes.map { byte in
+            // Pick a random character from the set, wrapping around if needed.
+            charset[Int(byte) % charset.count]
+        }
+        
+        return String(nonce)
+    }
+    
+    private func sha256(_ input: String) -> String {
+        let inputData = Data(input.utf8)
+        let hashedData = SHA256.hash(data: inputData)
+        let hashString = hashedData.compactMap {
+            String(format: "%02x", $0)
+        }.joined()
+        
+        return hashString
+    }
+}
+

--- a/Odya-iOS/Core/MainView.swift
+++ b/Odya-iOS/Core/MainView.swift
@@ -22,7 +22,7 @@ struct MainView: View {
                 Spacer()
                 
                 // 사용자 정보 - 프로필 닉네임
-                Text(getUserName())
+//                Text(getUserName())
                 
                 // logout button
                 Button(action: {kakaoAuthViewModel.kakaoLogout()}) {
@@ -52,20 +52,20 @@ struct MainView: View {
     // MARK: FUNCTIONS
     
     /// 화면에 표시할 카카오 프로필 닉네임 가져오기
-    func getUserName() -> String {
-        let kakaoUser = kakaoAuthViewModel.userInfo
-        
-        guard let user = kakaoUser else {
-            return "no user"
-        }
-        guard let account = user.kakaoAccount else {
-            return "no account"
-        }
-        guard let nickname = account.profile?.nickname else {
-            return "no nickname"
-        }
-        return nickname
-    }
+//    func getUserName() -> String {
+//        let kakaoUser = kakaoAuthViewModel.userInfo
+//
+//        guard let user = kakaoUser else {
+//            return "no user"
+//        }
+//        guard let account = user.kakaoAccount else {
+//            return "no account"
+//        }
+//        guard let nickname = account.profile?.nickname else {
+//            return "no nickname"
+//        }
+//        return nickname
+//    }
 
 }
 


### PR DESCRIPTION
### 개요
- 파이어베이스 연동

### 변경사항
- 애플 로그인 파이어베이스 연동, 파이어베이스 토큰으로 서버 로그인
- 카카오 서버 로그인 성공 시 받아오는 커스텀 토큰으로 파이어베이스 로그인

### 관련 지라 및 위키 링크
- [ODYA-84](https://weit.atlassian.net/browse/ODYA-84)

### 리뷰어에게 하고 싶은 말
- 애플 로그인의 경우, 파이어베이스 로그인 후 토큰으로 서버 로그인 진행까지 테스트 완료했습니다. 존재하지 않는 회원입니다 오류 메시지 나오는 것까지 확인했고, 출력되는 내용은 unknown으로 나오는데 이건 api 에러 디코딩 타입을 수정해야 되는 문제여서 넘어갔습니다!
- 카카오의 경우, 커스텀 토큰으로 파이어베이스 로그인 진행하는 코드까지는 구현을 해놓은 상태인데, 로그인이 성공해야 테스트를 해볼 수 있어서 회원가입까지 완료하면 테스트 해보겠습니다.
- 그리고 애플 로그인인 경우 유저 정보를 userdefaults로 저장해두고 있는데, 파이어베이스 연동해 놓은 상태여서 파이어베이스 토큰만 저장해두면 되지 않을까 싶습니당. 처음에 회원가입 시에만 유저 정보 파이어베이스로만 잘 넘겨주면 될 것 같아요. 토큰은 appstorage로 저장해놨어요
- GoogleService-Info.plist ignore, 슬랙으로 보낼게요
