### PR TITLE
ODYA-131 약관 API 연동

### DIFF
--- a/Odya-iOS.xcodeproj/project.pbxproj
+++ b/Odya-iOS.xcodeproj/project.pbxproj
@@ -35,6 +35,11 @@
 		07AF2B1D2A392F7800D54780 /* LocationSearchResultCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07AF2B1C2A392F7800D54780 /* LocationSearchResultCell.swift */; };
 		07AF2B212A39303800D54780 /* LocationSearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07AF2B202A39303800D54780 /* LocationSearchViewModel.swift */; };
 		07B725FA2A2A591A0024C5E8 /* AppleLoginButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07B725F92A2A591A0024C5E8 /* AppleLoginButton.swift */; };
+		19EBA7532AB16B7D000ABBE5 /* CombineMoya in Frameworks */ = {isa = PBXBuildFile; productRef = 19EBA7522AB16B7D000ABBE5 /* CombineMoya */; };
+		19EBA7552AB16B7D000ABBE5 /* Moya in Frameworks */ = {isa = PBXBuildFile; productRef = 19EBA7542AB16B7D000ABBE5 /* Moya */; };
+		19EBA7572AB16BDE000ABBE5 /* TermsRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19EBA7562AB16BDE000ABBE5 /* TermsRouter.swift */; };
+		19EBA7592AB16E2C000ABBE5 /* TermsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19EBA7582AB16E2C000ABBE5 /* TermsView.swift */; };
+		19EBA75B2AB16EAF000ABBE5 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 19EBA75A2AB16EAF000ABBE5 /* GoogleService-Info.plist */; };
 		3E0588FD2A276E64005C29D9 /* KakaoLoginButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E0588FC2A276E64005C29D9 /* KakaoLoginButton.swift */; };
 		3E0588FF2A276E76005C29D9 /* KakaoAuthViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E0588FE2A276E76005C29D9 /* KakaoAuthViewModel.swift */; };
 		3E0589012A276E84005C29D9 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E0589002A276E84005C29D9 /* AppDelegate.swift */; };
@@ -60,7 +65,6 @@
 		3E9E98932A8B7C7300909653 /* UserInfoValidatorRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E9E98922A8B7C7300909653 /* UserInfoValidatorRouter.swift */; };
 		3EBEC3912A6B1C2600998EC6 /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 3EBEC3902A6B1C2600998EC6 /* FirebaseAuth */; };
 		3EBEC3932A6B1D7F00998EC6 /* AppleAuthViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EBEC3922A6B1D7F00998EC6 /* AppleAuthViewModel.swift */; };
-		3EBEC39E2A6B293100998EC6 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3EBEC39D2A6B293100998EC6 /* GoogleService-Info.plist */; };
 		3EBEC3A22A6C38EC00998EC6 /* ComponetsTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EBEC3A12A6C38EC00998EC6 /* ComponetsTestView.swift */; };
 		3EBEC3A42A6C46B100998EC6 /* GNBButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EBEC3A32A6C46B100998EC6 /* GNBButton.swift */; };
 		3EBEC3A62A6D28AA00998EC6 /* ToggleButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EBEC3A52A6D28A900998EC6 /* ToggleButton.swift */; };
@@ -148,6 +152,9 @@
 		07AF2B202A39303800D54780 /* LocationSearchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationSearchViewModel.swift; sourceTree = "<group>"; };
 		07B725F82A2A50280024C5E8 /* Odya-iOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Odya-iOS.entitlements"; sourceTree = "<group>"; };
 		07B725F92A2A591A0024C5E8 /* AppleLoginButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleLoginButton.swift; sourceTree = "<group>"; };
+		19EBA7562AB16BDE000ABBE5 /* TermsRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsRouter.swift; sourceTree = "<group>"; };
+		19EBA7582AB16E2C000ABBE5 /* TermsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsView.swift; sourceTree = "<group>"; };
+		19EBA75A2AB16EAF000ABBE5 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		3E0588FC2A276E64005C29D9 /* KakaoLoginButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoLoginButton.swift; sourceTree = "<group>"; };
 		3E0588FE2A276E76005C29D9 /* KakaoAuthViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoAuthViewModel.swift; sourceTree = "<group>"; };
 		3E0589002A276E84005C29D9 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -166,7 +173,6 @@
 		3E9E988D2A84C9A400909653 /* AuthValidatorApiViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthValidatorApiViewModel.swift; sourceTree = "<group>"; };
 		3E9E98922A8B7C7300909653 /* UserInfoValidatorRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoValidatorRouter.swift; sourceTree = "<group>"; };
 		3EBEC3922A6B1D7F00998EC6 /* AppleAuthViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleAuthViewModel.swift; sourceTree = "<group>"; };
-		3EBEC39D2A6B293100998EC6 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../Downloads/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		3EBEC3A12A6C38EC00998EC6 /* ComponetsTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponetsTestView.swift; sourceTree = "<group>"; };
 		3EBEC3A32A6C46B100998EC6 /* GNBButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GNBButton.swift; sourceTree = "<group>"; };
 		3EBEC3A52A6D28A900998EC6 /* ToggleButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToggleButton.swift; sourceTree = "<group>"; };
@@ -233,9 +239,11 @@
 				3E8F81912A81128100FA167E /* GooglePlaces in Frameworks */,
 				3E3EC3B32A388ADE002BF519 /* webp in Frameworks */,
 				3E8F81952A8112AB00FA167E /* GoogleMapsCore in Frameworks */,
+				19EBA7552AB16B7D000ABBE5 /* Moya in Frameworks */,
 				3E3EC3AD2A388AA5002BF519 /* Alamofire in Frameworks */,
 				3E8F818F2A81127600FA167E /* GoogleMaps in Frameworks */,
 				3EBEC3912A6B1C2600998EC6 /* FirebaseAuth in Frameworks */,
+				19EBA7532AB16B7D000ABBE5 /* CombineMoya in Frameworks */,
 				3E8F81932A8112A500FA167E /* GoogleMapsBase in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -277,7 +285,7 @@
 				07DFFC102A2F6EA6006A2FB9 /* Model */,
 				07B725F82A2A50280024C5E8 /* Odya-iOS.entitlements */,
 				3E0589042A276EAD005C29D9 /* Info.plist */,
-				3EBEC39D2A6B293100998EC6 /* GoogleService-Info.plist */,
+				19EBA75A2AB16EAF000ABBE5 /* GoogleService-Info.plist */,
 				3E0589052A277063005C29D9 /* Config.xcconfig */,
 				071FA52F2A20ADA400C7B362 /* App */,
 				071FA5352A20AE6C00C7B362 /* Core */,
@@ -468,6 +476,7 @@
 				3EF7C1E72A742D1400223366 /* RegisterNicknameView.swift */,
 				3EF7C1E92A758A3200223366 /* RegisterDefaultInfoView.swift */,
 				3EF7C1EF2A8105F000223366 /* UserInfoPickerView.swift */,
+				19EBA7582AB16E2C000ABBE5 /* TermsView.swift */,
 			);
 			path = SignUp;
 			sourceTree = "<group>";
@@ -604,6 +613,7 @@
 				3EF54A022A5BE992006562F8 /* AuthRouter.swift */,
 				07310DAE2A6BB0CD0047E972 /* ReviewRouter.swift */,
 				3E9E98922A8B7C7300909653 /* UserInfoValidatorRouter.swift */,
+				19EBA7562AB16BDE000ABBE5 /* TermsRouter.swift */,
 			);
 			path = Routers;
 			sourceTree = "<group>";
@@ -642,6 +652,8 @@
 				3E8F81902A81128100FA167E /* GooglePlaces */,
 				3E8F81922A8112A500FA167E /* GoogleMapsBase */,
 				3E8F81942A8112AB00FA167E /* GoogleMapsCore */,
+				19EBA7522AB16B7D000ABBE5 /* CombineMoya */,
+				19EBA7542AB16B7D000ABBE5 /* Moya */,
 			);
 			productName = "Odya-iOS";
 			productReference = 071FA51E2A20A99F00C7B362 /* Odya-iOS.app */;
@@ -679,6 +691,7 @@
 				3E3EC3B42A388B55002BF519 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */,
 				07AF2B122A392AE300D54780 /* XCRemoteSwiftPackageReference "GoogleMaps-SP" */,
 				3EBEC38F2A6B1C2600998EC6 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
+				19EBA7512AB16B7D000ABBE5 /* XCRemoteSwiftPackageReference "Moya" */,
 			);
 			productRefGroup = 071FA51F2A20A99F00C7B362 /* Products */;
 			projectDirPath = "";
@@ -694,12 +707,12 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				19EBA75B2AB16EAF000ABBE5 /* GoogleService-Info.plist in Resources */,
 				3EF549972A4200EB006562F8 /* NotoSansKR-Black.otf in Resources */,
 				3EF549952A4200EB006562F8 /* OFL.txt in Resources */,
 				3EF549942A4200EB006562F8 /* NotoSansKR-Thin.otf in Resources */,
 				3EF549962A4200EB006562F8 /* NotoSansKR-Light.otf in Resources */,
 				3EF549B72A46ED30006562F8 /* 한국기계연구원_bold.ttf in Resources */,
-				3EBEC39E2A6B293100998EC6 /* GoogleService-Info.plist in Resources */,
 				3EF549912A4200EA006562F8 /* NotoSansKR-Medium.otf in Resources */,
 				3EF549B82A46ED30006562F8 /* 한국기계연구원_Light.ttf in Resources */,
 				071FA5292A20A9A000C7B362 /* Preview Assets.xcassets in Resources */,
@@ -732,6 +745,7 @@
 				3EBEC3B92A72AFAB00998EC6 /* ComponentSizeType.swift in Sources */,
 				3EF7C1EA2A758A3200223366 /* RegisterDefaultInfoView.swift in Sources */,
 				3EF54A0F2A5BF9BD006562F8 /* AuthViewModel.swift in Sources */,
+				19EBA7572AB16BDE000ABBE5 /* TermsRouter.swift in Sources */,
 				3EF54A0D2A5BEB22006562F8 /* AuthApiService.swift in Sources */,
 				07310DAF2A6BB0CD0047E972 /* ReviewRouter.swift in Sources */,
 				078496502A9760CF00A490E3 /* FishchipButton.swift in Sources */,
@@ -797,6 +811,7 @@
 				3EEBB7D32A8F50B300F0049D /* TravelDateView.swift in Sources */,
 				3EF7C1F02A8105F000223366 /* UserInfoPickerView.swift in Sources */,
 				3EF549FF2A5BE938006562F8 /* ApiClient.swift in Sources */,
+				19EBA7592AB16E2C000ABBE5 /* TermsView.swift in Sources */,
 				3EEBB7CD2A8E259800F0049D /* TravelJournalEditView.swift in Sources */,
 				3EF54A052A5BE9A8006562F8 /* Response.swift in Sources */,
 				3E800EC52A3E16D4001EA4C4 /* PhotoPickerView.swift in Sources */,
@@ -1048,6 +1063,14 @@
 				minimumVersion = 7.2.0;
 			};
 		};
+		19EBA7512AB16B7D000ABBE5 /* XCRemoteSwiftPackageReference "Moya" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Moya/Moya";
+			requirement = {
+				kind = upToNextMinorVersion;
+				minimumVersion = 15.0.0;
+			};
+		};
 		3E3EC3AB2A388AA5002BF519 /* XCRemoteSwiftPackageReference "Alamofire" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Alamofire/Alamofire.git";
@@ -1091,6 +1114,16 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		19EBA7522AB16B7D000ABBE5 /* CombineMoya */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 19EBA7512AB16B7D000ABBE5 /* XCRemoteSwiftPackageReference "Moya" */;
+			productName = CombineMoya;
+		};
+		19EBA7542AB16B7D000ABBE5 /* Moya */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 19EBA7512AB16B7D000ABBE5 /* XCRemoteSwiftPackageReference "Moya" */;
+			productName = Moya;
+		};
 		3E3EC3AC2A388AA5002BF519 /* Alamofire */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 3E3EC3AB2A388AA5002BF519 /* XCRemoteSwiftPackageReference "Alamofire" */;

--- a/Odya-iOS.xcodeproj/project.pbxproj
+++ b/Odya-iOS.xcodeproj/project.pbxproj
@@ -40,6 +40,9 @@
 		19EBA7572AB16BDE000ABBE5 /* TermsRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19EBA7562AB16BDE000ABBE5 /* TermsRouter.swift */; };
 		19EBA7592AB16E2C000ABBE5 /* TermsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19EBA7582AB16E2C000ABBE5 /* TermsView.swift */; };
 		19EBA75B2AB16EAF000ABBE5 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 19EBA75A2AB16EAF000ABBE5 /* GoogleService-Info.plist */; };
+		19EBA75D2AB2D38F000ABBE5 /* Terms.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19EBA75C2AB2D38F000ABBE5 /* Terms.swift */; };
+		19EBA75F2AB2E332000ABBE5 /* TermsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19EBA75E2AB2E332000ABBE5 /* TermsViewModel.swift */; };
+		19EBA7612AB2F027000ABBE5 /* HTMLTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19EBA7602AB2F027000ABBE5 /* HTMLTextView.swift */; };
 		3E0588FD2A276E64005C29D9 /* KakaoLoginButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E0588FC2A276E64005C29D9 /* KakaoLoginButton.swift */; };
 		3E0588FF2A276E76005C29D9 /* KakaoAuthViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E0588FE2A276E76005C29D9 /* KakaoAuthViewModel.swift */; };
 		3E0589012A276E84005C29D9 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E0589002A276E84005C29D9 /* AppDelegate.swift */; };
@@ -153,8 +156,11 @@
 		07B725F82A2A50280024C5E8 /* Odya-iOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Odya-iOS.entitlements"; sourceTree = "<group>"; };
 		07B725F92A2A591A0024C5E8 /* AppleLoginButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleLoginButton.swift; sourceTree = "<group>"; };
 		19EBA7562AB16BDE000ABBE5 /* TermsRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsRouter.swift; sourceTree = "<group>"; };
-		19EBA7582AB16E2C000ABBE5 /* TermsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsView.swift; sourceTree = "<group>"; };
+		19EBA7582AB16E2C000ABBE5 /* TermsView.swift */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = TermsView.swift; sourceTree = "<group>"; };
 		19EBA75A2AB16EAF000ABBE5 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		19EBA75C2AB2D38F000ABBE5 /* Terms.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Terms.swift; sourceTree = "<group>"; };
+		19EBA75E2AB2E332000ABBE5 /* TermsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsViewModel.swift; sourceTree = "<group>"; };
+		19EBA7602AB2F027000ABBE5 /* HTMLTextView.swift */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = HTMLTextView.swift; sourceTree = "<group>"; };
 		3E0588FC2A276E64005C29D9 /* KakaoLoginButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoLoginButton.swift; sourceTree = "<group>"; };
 		3E0588FE2A276E76005C29D9 /* KakaoAuthViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoAuthViewModel.swift; sourceTree = "<group>"; };
 		3E0589002A276E84005C29D9 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -220,7 +226,7 @@
 		3EF54A062A5BE9B9006562F8 /* Error.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
 		3EF54A082A5BE9DA006562F8 /* ApiService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApiService.swift; sourceTree = "<group>"; };
 		3EF54A0C2A5BEB22006562F8 /* AuthApiService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthApiService.swift; sourceTree = "<group>"; };
-		3EF54A0E2A5BF9BD006562F8 /* AuthViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthViewModel.swift; sourceTree = "<group>"; };
+		3EF54A0E2A5BF9BD006562F8 /* AuthViewModel.swift */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = AuthViewModel.swift; sourceTree = "<group>"; tabWidth = 4; };
 		3EF7C1E72A742D1400223366 /* RegisterNicknameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterNicknameView.swift; sourceTree = "<group>"; };
 		3EF7C1E92A758A3200223366 /* RegisterDefaultInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterDefaultInfoView.swift; sourceTree = "<group>"; };
 		3EF7C1EB2A7ABEFB00223366 /* SignUpView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpView.swift; sourceTree = "<group>"; };
@@ -437,6 +443,7 @@
 				3EF549B92A482B1D006562F8 /* UserAuth.swift */,
 				3EEBB7D62A91FACB00F0049D /* DailyTravelJournal.swift */,
 				3ED22F3D2A98D7070067DE72 /* FollowUserData.swift */,
+				19EBA75C2AB2D38F000ABBE5 /* Terms.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -463,6 +470,7 @@
 				3EF54A0E2A5BF9BD006562F8 /* AuthViewModel.swift */,
 				3E0588FE2A276E76005C29D9 /* KakaoAuthViewModel.swift */,
 				3EBEC3922A6B1D7F00998EC6 /* AppleAuthViewModel.swift */,
+				19EBA75E2AB2E332000ABBE5 /* TermsViewModel.swift */,
 				3E9E98902A8B7A2300909653 /* SignUp */,
 				071FA5302A20ADAC00C7B362 /* Login */,
 			);
@@ -473,10 +481,10 @@
 			isa = PBXGroup;
 			children = (
 				3EF7C1EB2A7ABEFB00223366 /* SignUpView.swift */,
+				19EBA7582AB16E2C000ABBE5 /* TermsView.swift */,
 				3EF7C1E72A742D1400223366 /* RegisterNicknameView.swift */,
 				3EF7C1E92A758A3200223366 /* RegisterDefaultInfoView.swift */,
 				3EF7C1EF2A8105F000223366 /* UserInfoPickerView.swift */,
-				19EBA7582AB16E2C000ABBE5 /* TermsView.swift */,
 			);
 			path = SignUp;
 			sourceTree = "<group>";
@@ -491,6 +499,7 @@
 				3EF7C1ED2A7AE7D000223366 /* FieldStyle.swift */,
 				3ED22F3B2A9854730067DE72 /* CustomNavigationBar.swift */,
 				0784964D2A908C1800A490E3 /* RoundedEdgeShape.swift */,
+				19EBA7602AB2F027000ABBE5 /* HTMLTextView.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -754,6 +763,7 @@
 				3EF7C1E82A742D1400223366 /* RegisterNicknameView.swift in Sources */,
 				3EF549A62A430ECD006562F8 /* Shadow.swift in Sources */,
 				3EBEC3B72A713F4E00998EC6 /* Profile.swift in Sources */,
+				19EBA75D2AB2D38F000ABBE5 /* Terms.swift in Sources */,
 				07AF2B212A39303800D54780 /* LocationSearchViewModel.swift in Sources */,
 				0732948A2A2C9975008E1026 /* UserDefaults.swift in Sources */,
 				3ED22F442AAA355B0067DE72 /* DailyJournalEditViewModel.swift in Sources */,
@@ -778,6 +788,7 @@
 				3EF54A012A5BE96D006562F8 /* BaseInterceptor.swift in Sources */,
 				078496492A84F72000A490E3 /* PostImageView.swift in Sources */,
 				3EF7C1F32A81099000223366 /* UserInfoEditView.swift in Sources */,
+				19EBA75F2AB2E332000ABBE5 /* TermsViewModel.swift in Sources */,
 				07A0EC7A2A3F8014002D36B9 /* AppleSignInManager.swift in Sources */,
 				3EF549B22A46E471006562F8 /* Radius.swift in Sources */,
 				3E0589012A276E84005C29D9 /* AppDelegate.swift in Sources */,
@@ -789,6 +800,7 @@
 				3EF7C1EE2A7AE7D000223366 /* FieldStyle.swift in Sources */,
 				3EF549862A419100006562F8 /* ColorStyles.swift in Sources */,
 				078496432A84F67D00A490E3 /* FeedToolBar.swift in Sources */,
+				19EBA7612AB2F027000ABBE5 /* HTMLTextView.swift in Sources */,
 				3EF549B42A46E4E3006562F8 /* GridLayout.swift in Sources */,
 				3EBEC3AF2A6E74DE00998EC6 /* ButtonStyles.swift in Sources */,
 				3ED22F3E2A98D7070067DE72 /* FollowUserData.swift in Sources */,

--- a/Odya-iOS.xcodeproj/project.pbxproj
+++ b/Odya-iOS.xcodeproj/project.pbxproj
@@ -989,7 +989,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 0.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.weit.Odya-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1032,7 +1032,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 0.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.weit.Odya-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Odya-iOS/Api/Result/Response.swift
+++ b/Odya-iOS/Api/Result/Response.swift
@@ -10,21 +10,6 @@ import Foundation
 // 디코딩 가능한 빈 Response
 struct EmptyResponse: Codable {}
 
-/**
- 테스트 API를 통해 이름을 전달한 뒤, 해시값과 이름을 받아 저장하는 모델
- - id: Hash Value
- - name: Original Name
- */
-struct TestNetworkResponse: Codable {
-    var id: Int
-    var name: String
-    
-    enum CodingKeys: String, CodingKey {
-        case id = "hashValue"
-        case name = "originalName"
-    }
-}
-
 /// 카카오 로그인 성공 시 response
 struct KakaoTokenResponse: Codable {
     var token: String

--- a/Odya-iOS/Api/Routers/AuthRouter.swift
+++ b/Odya-iOS/Api/Routers/AuthRouter.swift
@@ -18,13 +18,15 @@ enum AuthRouter: URLRequestConvertible {
                        phoneNumber: String?,
                        nickname: String,
                        gender: String,
-                       birthday: [Int])
+                       birthday: [Int],
+                       termsIdList: [Int])
     case kakaoRegister(username: String,
                        email: String?,
                        phoneNumber: String?,
                        nickname: String,
                        gender: String,
-                       birthday: [Int])
+                       birthday: [Int],
+                       termsIdList: [Int])
     case validateNickname(value: String)
     case validateEmail(value: String)
     case validatePhonenumber(value: String)
@@ -69,7 +71,7 @@ enum AuthRouter: URLRequestConvertible {
         case let .kakaoLogin(accessToken):
             let params: Parameters = ["accessToken" : accessToken]
             return params
-        case let .appleRegister(idToken, email, phoneNumber, nickname, gender, birthday):
+        case let .appleRegister(idToken, email, phoneNumber, nickname, gender, birthday, termsIdList):
             var params = Parameters()
             params["idToken"] = idToken
             params["email"] = email
@@ -77,8 +79,9 @@ enum AuthRouter: URLRequestConvertible {
             params["nickname"] = nickname
             params["gender"] = gender
             params["birthday"] = birthday
+            params["termsIdList"] = termsIdList
             return params
-        case let .kakaoRegister(username, email, phoneNumber, nickname, gender, birthday):
+        case let .kakaoRegister(username, email, phoneNumber, nickname, gender, birthday, termsIdList):
             var params = Parameters()
             params["username"] = username
             params["email"] = email
@@ -86,6 +89,7 @@ enum AuthRouter: URLRequestConvertible {
             params["nickname"] = nickname
             params["gender"] = gender
             params["birthday"] = birthday
+            params["termsIdList"] = termsIdList
             return params
         case .validateNickname(let value), .validateEmail(let value), .validatePhonenumber(let value):
             return ["value": value]

--- a/Odya-iOS/Api/Routers/TermsRouter.swift
+++ b/Odya-iOS/Api/Routers/TermsRouter.swift
@@ -1,0 +1,48 @@
+//
+//  TermsRouter.swift
+//  Odya-iOS
+//
+//  Created by Jade Yoo on 2023/09/13.
+//
+
+import Foundation
+import Moya
+
+enum TermsRouter {
+    case getTermsList
+    case getTermsContent(termsId: Int)
+}
+
+extension TermsRouter: TargetType {
+    var baseURL: URL {
+        return URL(string: ApiClient.BASE_URL)!
+    }
+    
+    var path: String {
+        switch self {
+        case .getTermsList:
+            return "/api/v1/auth/terms"
+        case .getTermsContent(let termsId):
+            return "/api/v1/auth/terms/\(termsId)"
+        }
+    }
+    
+    var method: Moya.Method {
+        switch self {
+        case .getTermsList, .getTermsContent:
+            return .get
+        }
+    }
+    
+    var task: Moya.Task {
+        switch self {
+        default: return .requestPlain
+        }
+    }
+    
+    var headers: [String : String]? {
+        return ["Content-type": "application/json" ]
+    }
+    
+    
+}

--- a/Odya-iOS/Api/Routers/TermsRouter.swift
+++ b/Odya-iOS/Api/Routers/TermsRouter.swift
@@ -36,7 +36,10 @@ extension TermsRouter: TargetType {
     
     var task: Moya.Task {
         switch self {
-        default: return .requestPlain
+        case .getTermsList:
+            return .requestPlain
+        case .getTermsContent:
+            return .requestPlain
         }
     }
     

--- a/Odya-iOS/Api/Services/AuthApiService.swift
+++ b/Odya-iOS/Api/Services/AuthApiService.swift
@@ -39,10 +39,11 @@ enum AuthApiService {
                               nickname: String,
                               phoneNumber: String?,
                               gender: String,
-                              birthday : [Int]) -> AnyPublisher<EmptyResponse, APIError> {
+                              birthday : [Int],
+                              termsIdList: [Int]) -> AnyPublisher<EmptyResponse, APIError> {
         // print("AuthApiService - appleRegister() called")
         
-        let request = ApiClient.shared.session.request(AuthRouter.appleRegister(idToken: idToken, email: email, phoneNumber: phoneNumber, nickname: nickname, gender: gender, birthday: birthday))
+        let request = ApiClient.shared.session.request(AuthRouter.appleRegister(idToken: idToken, email: email, phoneNumber: phoneNumber, nickname: nickname, gender: gender, birthday: birthday, termsIdList: termsIdList))
         
         return agent.run(request)
             .map(\.value)
@@ -54,10 +55,11 @@ enum AuthApiService {
                               phoneNumber: String?,
                               nickname: String,
                               gender: String,
-                              birthday: [Int]) -> AnyPublisher<EmptyResponse, APIError> {
+                              birthday: [Int],
+                              termsIdList: [Int]) -> AnyPublisher<EmptyResponse, APIError> {
         // print("AuthApiService - kakaoRegister() called")
         
-        let request = ApiClient.shared.session.request(AuthRouter.kakaoRegister(username: username, email: email, phoneNumber: phoneNumber, nickname: nickname, gender: gender, birthday: birthday))
+        let request = ApiClient.shared.session.request(AuthRouter.kakaoRegister(username: username, email: email, phoneNumber: phoneNumber, nickname: nickname, gender: gender, birthday: birthday, termsIdList: termsIdList))
         
         return agent.run(request)
             .map(\.value)

--- a/Odya-iOS/App/Odya_iOSApp.swift
+++ b/Odya-iOS/App/Odya_iOSApp.swift
@@ -30,13 +30,14 @@ struct Odya_iOSApp: App {
     // MARK: BODY
     var body: some Scene {
         WindowGroup {
-            if idToken != nil {
-                RootTabView()
-            } else {
-                LoginView()
-                    .environmentObject(appleAuthVM)
-                    .environmentObject(kakaoAuthVM)
-            }
+            TermsView()
+//            if idToken != nil {
+//                RootTabView()
+//            } else {
+//                LoginView()
+//                    .environmentObject(appleAuthVM)
+//                    .environmentObject(kakaoAuthVM)
+//            }
         }
     }
     

--- a/Odya-iOS/App/Odya_iOSApp.swift
+++ b/Odya-iOS/App/Odya_iOSApp.swift
@@ -30,14 +30,13 @@ struct Odya_iOSApp: App {
     // MARK: BODY
     var body: some Scene {
         WindowGroup {
-            TermsView()
-//            if idToken != nil {
-//                RootTabView()
-//            } else {
-//                LoginView()
-//                    .environmentObject(appleAuthVM)
-//                    .environmentObject(kakaoAuthVM)
-//            }
+            if idToken != nil {
+                RootTabView()
+            } else {
+                LoginView()
+                    .environmentObject(appleAuthVM)
+                    .environmentObject(kakaoAuthVM)
+            }
         }
     }
     

--- a/Odya-iOS/Components/HTMLTextView.swift
+++ b/Odya-iOS/Components/HTMLTextView.swift
@@ -1,0 +1,21 @@
+//
+//  HTMLTextView.swift
+//  Odya-iOS
+//
+//  Created by Jade Yoo on 2023/09/14.
+//
+
+import WebKit
+import SwiftUI
+
+struct HTMLTextView: UIViewRepresentable {
+  let htmlContent: String
+  
+  func makeUIView(context: Context) -> WKWebView {
+    return WKWebView()
+  }
+  
+  func updateUIView(_ uiView: WKWebView, context: Context) {
+    uiView.loadHTMLString(htmlContent, baseURL: nil)
+  }
+}

--- a/Odya-iOS/Core/Auth/AuthViewModel.swift
+++ b/Odya-iOS/Core/Auth/AuthViewModel.swift
@@ -28,6 +28,7 @@ class AuthViewModel: ObservableObject {
     nickname: String,
     gender: String,
     birthday: [Int],
+    termsIdList: [Int],
     completion: @escaping (Bool, String?) -> Void
   ) {
     print("AuthVM - kakaoRegister() called")
@@ -36,7 +37,7 @@ class AuthViewModel: ObservableObject {
 
     AuthApiService.kakaoRegister(
       username: username, email: email, phoneNumber: phoneNumber, nickname: nickname,
-      gender: gender, birthday: birthday
+      gender: gender, birthday: birthday, termsIdList: termsIdList
     )
     .sink { apiCompletion in
       switch apiCompletion {
@@ -69,6 +70,7 @@ class AuthViewModel: ObservableObject {
     nickname: String,
     gender: String,
     birthday: [Int],
+    termsIdList: [Int],
     completion: @escaping (Bool, String?) -> Void
   ) {
     print("AuthVM - appleRegister() called")
@@ -77,7 +79,7 @@ class AuthViewModel: ObservableObject {
 
     AuthApiService.appleRegister(
       idToken: idToken, email: email, nickname: nickname, phoneNumber: phoneNumber, gender: gender,
-      birthday: birthday
+      birthday: birthday, termsIdList: termsIdList
     )
     .sink { apiCompletion in
       switch apiCompletion {

--- a/Odya-iOS/Core/Auth/SignUp/RegisterDefaultInfoView.swift
+++ b/Odya-iOS/Core/Auth/SignUp/RegisterDefaultInfoView.swift
@@ -143,7 +143,7 @@ struct RegisterDefaultInfoView: View {
 struct RegisterDefaultInfoView_Previews: PreviewProvider {
   static var previews: some View {
     RegisterDefaultInfoView(
-      step: .constant(2),
+      step: .constant(3),
       nickname: "길동아밥먹자",
       birthday: .constant(Date()),
       gender: .constant(Gender.none))

--- a/Odya-iOS/Core/Auth/SignUp/RegisterNicknameView.swift
+++ b/Odya-iOS/Core/Auth/SignUp/RegisterNicknameView.swift
@@ -57,6 +57,6 @@ struct RegisterNicknameView: View {
 
 struct RegisterNicknameView_Previews: PreviewProvider {
   static var previews: some View {
-    RegisterNicknameView(step: .constant(1), nickname: .constant("홍길동"))
+    RegisterNicknameView(step: .constant(2), nickname: .constant("홍길동"))
   }
 }

--- a/Odya-iOS/Core/Auth/SignUp/SignUpView.swift
+++ b/Odya-iOS/Core/Auth/SignUp/SignUpView.swift
@@ -95,7 +95,7 @@ struct SignUpView: View {
               print("do apple register")
               authApi.appleRegister(
                 idToken: userInfo.idToken, email: userInfo.email, phoneNumber: userInfo.phoneNumber,
-                nickname: userInfo.nickname, gender: genderString, birthday: birthdayArray
+                nickname: userInfo.nickname, gender: genderString, birthday: birthdayArray, termsIdList: userInfo.termsIdList
               ) { result, errorMessage in
                 guard result else {
                   print("Error in SignUpView appleRegister() - \(String(describing: errorMessage))")
@@ -109,7 +109,7 @@ struct SignUpView: View {
               authApi.kakaoRegister(
                 username: userInfo.username, email: userInfo.email,
                 phoneNumber: userInfo.phoneNumber, nickname: userInfo.nickname,
-                gender: genderString, birthday: birthdayArray
+                gender: genderString, birthday: birthdayArray, termsIdList: userInfo.termsIdList
               ) { result, errorMessage in
                 guard result else {
                   print("Error in SignUpView kakaoRegister() - \(String(describing: errorMessage))")

--- a/Odya-iOS/Core/Auth/SignUp/SignUpView.swift
+++ b/Odya-iOS/Core/Auth/SignUp/SignUpView.swift
@@ -45,7 +45,7 @@ struct SignupHeaderBar: View {
 
   var SignupStepIndicator: some View {
     HStack(spacing: 8) {
-      ForEach(1...4, id: \.self) { index in
+      ForEach(1...5, id: \.self) { index in
         Circle()
           .frame(width: 8, height: 8)
           .foregroundColor(step >= index ? .odya.brand.primary : .odya.system.inactive)
@@ -75,16 +75,20 @@ struct SignUpView: View {
       // contents
       switch step {
       case 1:
+          TermsView(
+            step: $step,
+            termsList: $userInfo.termsIdList)
+      case 2:
         RegisterNicknameView(
           step: $step,
           nickname: $userInfo.nickname)
-      case 2:
+      case 3:
         RegisterDefaultInfoView(
           step: $step,
           nickname: userInfo.nickname,
           birthday: $userInfo.birthday,
           gender: $userInfo.gender)
-      case 3:
+      case 4:
         ProgressView()
           .onAppear {
             let birthdayArray = getBirthdayArray(userInfo.birthday)

--- a/Odya-iOS/Core/Auth/SignUp/TermsView.swift
+++ b/Odya-iOS/Core/Auth/SignUp/TermsView.swift
@@ -1,0 +1,24 @@
+//
+//  TermsView.swift
+//  Odya-iOS
+//
+//  Created by Jade Yoo on 2023/09/13.
+//
+
+import SwiftUI
+
+struct TermsView: View {
+    // MARK: Properties
+    
+    // MARK: Body
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+// MARK: - Preview
+struct TermsView_Previews: PreviewProvider {
+    static var previews: some View {
+        TermsView()
+    }
+}

--- a/Odya-iOS/Core/Auth/SignUp/TermsView.swift
+++ b/Odya-iOS/Core/Auth/SignUp/TermsView.swift
@@ -8,17 +8,100 @@
 import SwiftUI
 
 struct TermsView: View {
-    // MARK: Properties
-    
-    // MARK: Body
-    var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+  // MARK: Properties
+  
+  @StateObject var viewModel = TermsViewModel()
+  @State var showSheet: Bool = false
+  @Binding var termsList: [Int]
+  
+  // MARK: Body
+  
+  var body: some View {
+    VStack {
+      Text("약관 안내")
+        .h3Style()
+      
+      List(viewModel.termsList, id: \.id) { terms in
+        HStack {
+          Image(systemName: "checkmark")
+            .foregroundColor(termsList.contains(terms.id) ? Color.odya.system.safe : Color.odya.system.inactive)
+          
+          if terms.isRequired {
+            Text("(필수)")
+              .detail1Style()
+          } else {
+            Text("(선택)")
+              .detail2Style()
+          }
+          
+          Text(terms.title)
+          Spacer()
+          Button {
+            showSheet.toggle()
+          } label: {
+            Text("보기")
+          }
+        }
+        .sheet(isPresented: $showSheet) {
+          TermsContentSheet(id: terms.id, title: terms.title)
+            .presentationDetents([.medium, .large])
+            .presentationDragIndicator(.visible)
+            .environmentObject(viewModel)
+        }
+      } // List
+      
+      CTAButton(isActive: .active, buttonStyle: .solid, labelText: "다음으로", labelSize: .L) {
+        // 다음 페이지로
+      }
+      .disabled(!termsList.contains(viewModel.requiredList) || viewModel.requiredList.isEmpty)
+    } // VStack
+    .task {
+      viewModel.getTermsList()
     }
+  }
+}
+
+struct TermsContentSheet: View {
+  // MARK: Properties
+  @EnvironmentObject var viewModel: TermsViewModel
+  @Environment(\.dismiss) var dismiss
+  let id: Int
+  let title: String
+  
+  // MARK: Body
+  
+  var body: some View {
+    VStack(spacing: GridLayout.spacing) {
+      // title
+      HStack {
+        Text(title)
+          .h3Style()
+          .foregroundColor(Color.odya.label.normal)
+          .padding(.vertical, 20)
+        Spacer()
+      }
+      // content
+      HTMLTextView(htmlContent: viewModel.termsContent)
+      Spacer()
+      // consent button
+      CTAButton(isActive: .active, buttonStyle: .solid,
+                labelText: "동의하기", labelSize: .L) {
+        dismiss()
+      }
+    }
+    .padding(.horizontal, GridLayout.side)
+    .frame(width: UIScreen.main.bounds.width)
+    .background(Color.odya.background.normal)
+    .task {
+      viewModel.getTermsContent(id: id)
+    }
+  }
 }
 
 // MARK: - Preview
+
 struct TermsView_Previews: PreviewProvider {
-    static var previews: some View {
-        TermsView()
-    }
+  static var previews: some View {
+    TermsView(termsList: [1, 2 ,3])
+  }
 }

--- a/Odya-iOS/Core/Auth/SignUp/TermsView.swift
+++ b/Odya-iOS/Core/Auth/SignUp/TermsView.swift
@@ -9,31 +9,34 @@ import SwiftUI
 
 struct TermsView: View {
   // MARK: Properties
-  
+
   @StateObject var viewModel = TermsViewModel()
   @State var showSheet: Bool = false
+  @Binding var step: Int
   @Binding var termsList: [Int]
-  
+
   // MARK: Body
-  
+
   var body: some View {
     VStack {
       Text("약관 안내")
         .h3Style()
-      
+
       List(viewModel.termsList, id: \.id) { terms in
         HStack {
           Image(systemName: "checkmark")
-            .foregroundColor(termsList.contains(terms.id) ? Color.odya.system.safe : Color.odya.system.inactive)
-          
+            .foregroundColor(
+              termsList.contains(terms.id) ? Color.odya.system.safe : Color.odya.system.inactive)
+
           if terms.isRequired {
             Text("(필수)")
               .detail1Style()
+              .foregroundColor(Color.odya.brand.primary)
           } else {
             Text("(선택)")
               .detail2Style()
           }
-          
+
           Text(terms.title)
           Spacer()
           Button {
@@ -43,18 +46,18 @@ struct TermsView: View {
           }
         }
         .sheet(isPresented: $showSheet) {
-          TermsContentSheet(id: terms.id, title: terms.title)
+          TermsContentSheet(agreedTermsList: $termsList, id: terms.id, title: terms.title)
             .presentationDetents([.medium, .large])
             .presentationDragIndicator(.visible)
             .environmentObject(viewModel)
         }
-      } // List
-      
+      }  // List
+
       CTAButton(isActive: .active, buttonStyle: .solid, labelText: "다음으로", labelSize: .L) {
-        // 다음 페이지로
+        self.step += 1
       }
       .disabled(!termsList.contains(viewModel.requiredList) || viewModel.requiredList.isEmpty)
-    } // VStack
+    }  // VStack
     .task {
       viewModel.getTermsList()
     }
@@ -65,11 +68,12 @@ struct TermsContentSheet: View {
   // MARK: Properties
   @EnvironmentObject var viewModel: TermsViewModel
   @Environment(\.dismiss) var dismiss
+  @Binding var agreedTermsList: [Int]
   let id: Int
   let title: String
-  
+
   // MARK: Body
-  
+
   var body: some View {
     VStack(spacing: GridLayout.spacing) {
       // title
@@ -84,8 +88,11 @@ struct TermsContentSheet: View {
       HTMLTextView(htmlContent: viewModel.termsContent)
       Spacer()
       // consent button
-      CTAButton(isActive: .active, buttonStyle: .solid,
-                labelText: "동의하기", labelSize: .L) {
+      CTAButton(
+        isActive: .active, buttonStyle: .solid,
+        labelText: "동의하기", labelSize: .L
+      ) {
+        agreedTermsList.append(id)
         dismiss()
       }
     }
@@ -102,6 +109,6 @@ struct TermsContentSheet: View {
 
 struct TermsView_Previews: PreviewProvider {
   static var previews: some View {
-    TermsView(termsList: [1, 2 ,3])
+    TermsView(step: .constant(1), termsList: .constant([1, 2, 3]))
   }
 }

--- a/Odya-iOS/Core/Auth/TermsViewModel.swift
+++ b/Odya-iOS/Core/Auth/TermsViewModel.swift
@@ -1,0 +1,66 @@
+//
+//  TermsViewModel.swift
+//  Odya-iOS
+//
+//  Created by Jade Yoo on 2023/09/14.
+//
+
+import Foundation
+import Combine
+import CombineMoya
+import Moya
+
+final class TermsViewModel: ObservableObject {
+    private let plugin: PluginType = NetworkLoggerPlugin(configuration: .init(logOptions: .verbose))
+    private lazy var termsProvider = MoyaProvider<TermsRouter>(plugins: [plugin])
+    private var subscription = Set<AnyCancellable>()
+
+    @Published var termsList: TermsList = []
+    @Published var requiredList: [Int] = []
+    @Published var termsContent: String = ""
+
+    /// 약관리스트 조회
+    func getTermsList() {
+      termsProvider.requestPublisher(.getTermsList)
+        .sink { completion in
+          switch completion {
+          case .finished:
+            debugPrint("DEBUG: 약관 리스트 조회 완료")
+          case .failure(let error):
+            if let errorData = try? error.response?.map(ErrorData.self) {
+              print(errorData.message)
+            }
+          }
+        } receiveValue: { response in
+          if let data = try? response.map(TermsList.self) {
+            self.termsList = data
+              self.requiredList = self.termsList.compactMap {
+                  if $0.isRequired == true {
+                  return $0.id
+                  }
+              }
+          }
+        }
+        .store(in: &subscription)
+    }
+    
+    /// 약관내용 조회
+    func getTermsContent(id: Int) {
+      termsProvider.requestPublisher(.getTermsContent(termsId: id))
+        .sink { completion in
+          switch completion {
+          case .finished:
+            debugPrint("DEBUG: 약관 내용 조회 완료")
+          case .failure(let error):
+            if let errorData = try? error.response?.map(ErrorData.self) {
+              print(errorData.message)
+            }
+          }
+        } receiveValue: { response in
+          if let data = try? response.map(TermsContent.self) {
+            self.termsContent = data.content
+          }
+        }
+        .store(in: &subscription)
+    }
+}

--- a/Odya-iOS/Core/Auth/TermsViewModel.swift
+++ b/Odya-iOS/Core/Auth/TermsViewModel.swift
@@ -5,62 +5,58 @@
 //  Created by Jade Yoo on 2023/09/14.
 //
 
-import Foundation
 import Combine
 import CombineMoya
+import Foundation
 import Moya
 
 final class TermsViewModel: ObservableObject {
-    private let plugin: PluginType = NetworkLoggerPlugin(configuration: .init(logOptions: .verbose))
-    private lazy var termsProvider = MoyaProvider<TermsRouter>(plugins: [plugin])
-    private var subscription = Set<AnyCancellable>()
+  private let plugin: PluginType = NetworkLoggerPlugin(configuration: .init(logOptions: .verbose))
+  private lazy var termsProvider = MoyaProvider<TermsRouter>(plugins: [plugin])
+  private var subscription = Set<AnyCancellable>()
 
-    @Published var termsList: TermsList = []
-    @Published var requiredList: [Int] = []
-    @Published var termsContent: String = ""
+  @Published var termsList: TermsList = []
+  @Published var requiredList: [Int] = []
+  @Published var termsContent: String = ""
 
-    /// 약관리스트 조회
-    func getTermsList() {
-      termsProvider.requestPublisher(.getTermsList)
-        .sink { completion in
-          switch completion {
-          case .finished:
-            debugPrint("DEBUG: 약관 리스트 조회 완료")
-          case .failure(let error):
-            if let errorData = try? error.response?.map(ErrorData.self) {
-              print(errorData.message)
-            }
-          }
-        } receiveValue: { response in
-          if let data = try? response.map(TermsList.self) {
-            self.termsList = data
-              self.requiredList = self.termsList.compactMap {
-                  if $0.isRequired == true {
-                  return $0.id
-                  }
-              }
+  /// 약관리스트 조회
+  func getTermsList() {
+    termsProvider.requestPublisher(.getTermsList)
+      .sink { completion in
+        switch completion {
+        case .finished:
+          debugPrint("DEBUG: 약관 리스트 조회 완료")
+        case .failure(let error):
+          if let errorData = try? error.response?.map(ErrorData.self) {
+            print(errorData.message)
           }
         }
-        .store(in: &subscription)
-    }
-    
-    /// 약관내용 조회
-    func getTermsContent(id: Int) {
-      termsProvider.requestPublisher(.getTermsContent(termsId: id))
-        .sink { completion in
-          switch completion {
-          case .finished:
-            debugPrint("DEBUG: 약관 내용 조회 완료")
-          case .failure(let error):
-            if let errorData = try? error.response?.map(ErrorData.self) {
-              print(errorData.message)
-            }
-          }
-        } receiveValue: { response in
-          if let data = try? response.map(TermsContent.self) {
-            self.termsContent = data.content
+      } receiveValue: { response in
+        if let data = try? response.map(TermsList.self) {
+          self.termsList = data
+          self.requiredList = self.termsList.filter { $0.isRequired == true }.map { $0.id }
+        }
+      }
+      .store(in: &subscription)
+  }
+
+  /// 약관내용 조회
+  func getTermsContent(id: Int) {
+    termsProvider.requestPublisher(.getTermsContent(termsId: id))
+      .sink { completion in
+        switch completion {
+        case .finished:
+          debugPrint("DEBUG: 약관 내용 조회 완료")
+        case .failure(let error):
+          if let errorData = try? error.response?.map(ErrorData.self) {
+            print(errorData.message)
           }
         }
-        .store(in: &subscription)
-    }
+      } receiveValue: { response in
+        if let data = try? response.map(TermsContent.self) {
+          self.termsContent = data.content
+        }
+      }
+      .store(in: &subscription)
+  }
 }

--- a/Odya-iOS/Model/Terms.swift
+++ b/Odya-iOS/Model/Terms.swift
@@ -1,0 +1,28 @@
+//
+//  Terms.swift
+//  Odya-iOS
+//
+//  Created by Jade Yoo on 2023/09/14.
+//
+
+import Foundation
+
+// MARK: - Terms
+struct Terms: Codable {
+    let id: Int
+    let title: String
+    let isRequired: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case id, title
+        case isRequired = "required"
+    }
+}
+
+typealias TermsList = [Terms]
+
+// MARK: - TermsContent
+struct TermsContent: Codable {
+    let id: Int
+    let content: String
+}

--- a/Odya-iOS/Model/UserAuth.swift
+++ b/Odya-iOS/Model/UserAuth.swift
@@ -36,6 +36,7 @@ struct UserInfo {
     var phoneNumber: String? = nil
     var gender: Gender = .none
     var birthday: Date = Date()
+    var termsIdList: [Int] = []
     
 //    static func getDummy() -> Self {
 //        return UserInfo(idToken: "testIdToken", username: "KAKAO_1234", email: "test@test.com", nickname: "testNickname", gender: "M", birthday: [1999, 10, 10])


### PR DESCRIPTION
### 개요
약관 API 연동, 임시 약관 뷰 추가

### 변경사항
- 약관 API 라우터 추가 및 Moya 라이브러리 사용
- 닉네임 입력 뷰 앞 순서에 임시 약관 뷰 추가
- 회원가입 기능에 약관리스트 변수 or 파라미터 자잘하게 추가

### 관련 지라 및 위키 링크
[ODYA-131](https://weit.atlassian.net/browse/ODYA-131)

### 리뷰어에게 하고 싶은 말
모야 사용하는게 괜찮은지 한번 봐주세요 지금 네트워크 레이어랑 거의 비슷해서 바꿀 필요성이 안느껴질지도..?
