### PR TITLE
FEAT: ODYA-166 여행일지 api Router

### DIFF
--- a/Odya-iOS.xcodeproj/project.pbxproj
+++ b/Odya-iOS.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		3E3EC3B02A388AC0002BF519 /* SwiftyJSON in Frameworks */ = {isa = PBXBuildFile; productRef = 3E3EC3AF2A388AC0002BF519 /* SwiftyJSON */; };
 		3E3EC3B32A388ADE002BF519 /* webp in Frameworks */ = {isa = PBXBuildFile; productRef = 3E3EC3B22A388ADE002BF519 /* webp */; };
 		3E3EC3B62A388B55002BF519 /* KakaoSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 3E3EC3B52A388B55002BF519 /* KakaoSDK */; };
+		3E414B2E2ADB283B00034FBB /* TravelJournalRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E414B2D2ADB283B00034FBB /* TravelJournalRouter.swift */; };
 		3E800EBD2A3D9FF0001EA4C4 /* WebpViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E800EBC2A3D9FF0001EA4C4 /* WebpViewModel.swift */; };
 		3E800EBF2A3DAD7D001EA4C4 /* UIImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E800EBE2A3DAD7D001EA4C4 /* UIImage.swift */; };
 		3E800EC12A3E1561001EA4C4 /* WebpTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E800EC02A3E1561001EA4C4 /* WebpTestView.swift */; };
@@ -192,6 +193,7 @@
 		3E25FAB82A8280AD00ADF6E2 /* UserInfoField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoField.swift; sourceTree = "<group>"; };
 		3E25FABA2A8434CC00ADF6E2 /* Binding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Binding.swift; sourceTree = "<group>"; };
 		3E36EC722A2B596C006008E5 /* MainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainView.swift; sourceTree = "<group>"; };
+		3E414B2D2ADB283B00034FBB /* TravelJournalRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TravelJournalRouter.swift; sourceTree = "<group>"; };
 		3E800EBC2A3D9FF0001EA4C4 /* WebpViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebpViewModel.swift; sourceTree = "<group>"; };
 		3E800EBE2A3DAD7D001EA4C4 /* UIImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = UIImage.swift; path = "Odya-iOS/Extensions/UIImage.swift"; sourceTree = SOURCE_ROOT; };
 		3E800EC02A3E1561001EA4C4 /* WebpTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebpTestView.swift; sourceTree = "<group>"; };
@@ -732,6 +734,7 @@
 				3E9E98922A8B7C7300909653 /* UserInfoValidatorRouter.swift */,
 				19EBA7562AB16BDE000ABBE5 /* TermsRouter.swift */,
 				3EE9CA1A2AB5D67A003A2E85 /* FollowRouter.swift */,
+				3E414B2D2ADB283B00034FBB /* TravelJournalRouter.swift */,
 				3EE9CA1C2AB6C44B003A2E85 /* UserRouter.swift */,
 			);
 			path = Routers;
@@ -917,6 +920,7 @@
 				3EE9CA392AC41605003A2E85 /* DailyJournalView.swift in Sources */,
 				3EF549B22A46E471006562F8 /* Radius.swift in Sources */,
 				3E0589012A276E84005C29D9 /* AppDelegate.swift in Sources */,
+				3E414B2E2ADB283B00034FBB /* TravelJournalRouter.swift in Sources */,
 				3E0588FD2A276E64005C29D9 /* KakaoLoginButton.swift in Sources */,
 				07310DB62A7286380047E972 /* ReviewApiService.swift in Sources */,
 				3E0589032A276E8C005C29D9 /* SceneDelegate.swift in Sources */,

--- a/Odya-iOS/Api/Routers/TravelJournalRouter.swift
+++ b/Odya-iOS/Api/Routers/TravelJournalRouter.swift
@@ -1,0 +1,132 @@
+//
+//  TravelJournalRouter.swift
+//  Odya-iOS
+//
+//  Created by Heeoh Son on 2023/10/15.
+//
+
+import SwiftUI
+import Moya
+
+enum TravelJournalRouter {
+    case create(token: String, journal: TravelJournalData, images: [UIImage])
+    case searchById(token: String, journalId: Int)
+    case getJournals(token: String, size: Int?, lastId: Int?)
+    case getMyJournals(token: String, size: Int?, lastId: Int?)
+    case getFriendsJournals(token: String, size: Int?, lastId: Int?)
+    case getRecommendedJournals(token: String, size: Int?, lastId: Int?)
+    case getTaggedJournals(token: String, size: Int?, lastId: Int?)
+    case edit(token: String, journalId: Int)
+    case editContent(token: String, journalId: Int, contentId: Int)
+    case delete(token: String, journalId: Int)
+    case deleteContent(token: String, journalId: Int, contentId: Int)
+    case deleteTravelMates(token: String, journalId: Int)
+}
+
+extension TravelJournalRouter: TargetType, AccessTokenAuthorizable {
+    
+    var baseURL: URL {
+        return URL(string: ApiClient.BASE_URL)!
+    }
+    
+    var path: String {
+        switch self {
+        case .create, .getJournals:
+            return "/api/v1/travel-journals"
+        case let .searchById(_, journalId),
+            let .edit(_, journalId),
+            let .delete(_, journalId):
+            return "/api/v1/travel-journals/\(journalId)"
+        case let .editContent(_, journalId, contentId),
+            let .deleteContent(_, journalId, contentId):
+            return "/api/v1/travel-journals/\(journalId)/\(contentId)"
+        case let .deleteTravelMates(_, journalId):
+            return "/api/v1/travel-journals/\(journalId)/travelCompanion"
+        case .getMyJournals:
+            return "/api/v1/travel-journals/me"
+        case .getFriendsJournals:
+            return "/api/v1/travel-journals/friends"
+        case .getRecommendedJournals:
+            return "/api/v1/travel-journals/recommends"
+        case .getTaggedJournals:
+            return "/api/v1/travel-journals/tagged"
+        }
+    }
+    
+    var method: Moya.Method {
+        switch self {
+        case .create:
+            return .post
+        case .edit, .editContent:
+            return .put
+        case .delete, .deleteContent, .deleteTravelMates:
+            return .delete
+        default:
+            return .get
+        }
+    }
+    
+    var task: Moya.Task {
+        switch self {
+            // TODO: Create, Edit, EditContent
+        case let .create(_, journal, images):
+            var params: [String: Any] = [:]
+            params["title"] = journal.title
+            params["travelStartDate"] = journal.travelStartDate
+            params["travelEndDate"] = journal.travelEndDate
+            params["visibility"] = journal.visibility
+            params["travelCompanionIds"] = journal.travelMates.map { $0.userId }
+//            params["travelJournalContentRequests"] =
+//            travelJournalContentRequests(List<Object>): 여행 일지 콘텐츠 목록(Not Null) travelJournalContentRequests.content(String): 여행 일지 콘텐츠 내용(Nullable) travelJournalContentRequests.placeId(String): 여행 일지 콘텐츠 장소 아이디(Nullable) travelJournalContentRequests.latitudes(List<Double>): 여행 일지 콘텐츠 위도 목록(Nullable) travelJournalContentRequests.longitudes(List<Double>): 여행 일지 콘텐츠 경도 목록(Nullable) travelJournalContentRequests.travelDate(String): 여행 일지 콘텐츠 일자(Not Null) travelJournalContentRequests.contentImageNames(List<String>): 여행 일지 콘텐츠 사진 제목 + 형식(Not NULL)
+            
+            var multipartData = [MultipartFormData]()
+//            let jsonType = try? JSONEncoder().encode(params)
+//            let formData = MultipartFormData(provider: .data(jsonType!), name: "travel-journal", fileName: "travel-journal", mimeType: "application/json")
+//            multipartData.append(formData)
+//
+//            for (index, image) in images.enumerated() {
+//                multipartData.append(MultipartFormData(provider: .data(images), name: "travel-journal-content-image", fileName: "example_file\(index).webp", mimeType: "image/webp"))
+//            }
+            return .uploadMultipart(multipartData)
+        case let .getJournals(_, size, lastId),
+            let .getMyJournals(_, size, lastId),
+            let .getFriendsJournals(_, size, lastId),
+            let .getRecommendedJournals(_, size, lastId),
+            let .getTaggedJournals(_, size, lastId):
+            var params: [String: Any] = [:]
+            if let size = size {
+                params["size"] = size
+            }
+            if let lastId = lastId {
+                params["lastId"] = lastId
+            }
+            return .requestParameters(parameters: params, encoding: URLEncoding.queryString)
+        default:
+            return .requestPlain
+        }
+    }
+    
+    var headers: [String : String]? {
+        switch self {
+        case let .create(token, _, _),
+            let .searchById(token, _),
+            let .getJournals(token, _, _),
+            let .getMyJournals(token, _, _),
+            let .getFriendsJournals(token, _, _),
+            let .getRecommendedJournals(token, _, _),
+            let .getTaggedJournals(token, _, _),
+            let .edit(token, _),
+            let .editContent(token, _, _),
+            let .delete(token, _),
+            let .deleteContent(token, _, _),
+            let .deleteTravelMates(token, _):
+            return ["Authorization" : "Bearer \(token)"]
+        }
+    }
+    
+    var authorizationType: Moya.AuthorizationType? {
+        return .bearer
+    }
+    
+    
+}

--- a/Odya-iOS/Extensions/Date.swift
+++ b/Odya-iOS/Extensions/Date.swift
@@ -15,6 +15,12 @@ extension Date {
         return dateFormatter.string(from: self)
     }
     
+    func toIntArray() -> [Int] {
+        let calendar = Calendar.current
+        let components = calendar.dateComponents([.year, .month, .day], from: self)
+        return [components.year ?? 0, components.month ?? 0, components.day ?? 0]
+    }
+    
     func addDays(_ daysToAdd: Int) -> Date? {
         var components = DateComponents()
         components.day = daysToAdd

--- a/Odya-iOS/Model/DailyTravelJournal.swift
+++ b/Odya-iOS/Model/DailyTravelJournal.swift
@@ -12,6 +12,7 @@ struct ImageData: Identifiable, Hashable {
     var id = UUID()
     var assetIdentifier: String
     var image: UIImage
+    var imageName: String = ""
     var creationDate: Date? = nil
     var location: CLLocationCoordinate2D?
     // exif
@@ -36,8 +37,9 @@ struct DailyTravelJournal: Identifiable {
   var date: Date? = nil
   var content: String = ""
   var images: [ImageData] = []
-  // 사진 리스트
-  // 태그된 장소 정보
+    var placeId: String? = nil
+    var latitudes: [Double] = []
+    var longitudes: [Double] = []
 
   func getDayIndex(startDate: Date) -> Int {
     let calendar = Calendar.current


### PR DESCRIPTION
### 개요
- 여행일지 관련 api 라우터

### 변경사항
- 여행일지 api 라우터 (TravelJournalRouter) 추가
- 여행일지 생성/수정 시 request를 보내기 위한 struct 추가

### 관련 지라 및 위키 링크
- [ODYA-166](https://weit.atlassian.net/browse/ODYA-166)

### 리뷰어에게 하고 싶은 말
- 여행일지 생성/수정 시에는 MultiPart를 이용해 데이터 및 이미지를 전달했습니다. 
이 부분이 정상작동 하는지는 아직 테스트해보지 못했습니당... api 뷰에 연동하면서 같이 해볼게요.
