### PR TITLE
FEAT: ODYA-197 사진 리사이징시 방향 회전 수정

### DIFF
--- a/Odya-iOS/Extensions/UIImage.swift
+++ b/Odya-iOS/Extensions/UIImage.swift
@@ -13,7 +13,9 @@ extension UIImage {
         if self.size.width <= 1024 && self.size.height <= 1024 {
             return self
         }
-        
+      
+        let removedOrientationImage = removedOrientationImage(self)
+      
         let scaleFactor = min(maxSize / self.size.width, maxSize / self.size.height)
         let scaledWidth = self.size.width * scaleFactor
         let scaledHeight = self.size.height * scaleFactor
@@ -27,7 +29,7 @@ extension UIImage {
         else { return nil }
         
         context.interpolationQuality = .high
-        context.draw(self.cgImage!, in: CGRect(x: 0, y: 0, width: scaledWidth, height: scaledHeight))
+        context.draw(removedOrientationImage.cgImage!, in: CGRect(x: 0, y: 0, width: scaledWidth, height: scaledHeight))
         
         guard let scaledImage = context.makeImage() else {
             return nil
@@ -35,5 +37,17 @@ extension UIImage {
         
         let resizedImage = UIImage(cgImage: scaledImage)
         return resizedImage
+    }
+  
+    /// 사진 방향 제거
+    func removedOrientationImage(_ image: UIImage) -> UIImage {
+        guard image.imageOrientation != .up else { return image } // up 방향일때 제외
+      
+        UIGraphicsBeginImageContextWithOptions(image.size, false, image.scale)
+        image.draw(in: CGRect(origin: .zero, size: image.size))
+        let normalizedImage = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+      
+        return normalizedImage ?? image
     }
 }


### PR DESCRIPTION
### 개요
사진 리사이징시 방향 회전 수정

### 변경사항
- `UIImage` - `resizeAsync` 함수에서 리사이징 하기 전에 기존 사진 방향이 up이 아니면 이미지를 다시 그립니다.

<img src="https://github.com/weIT-1st/Odya-iOS/assets/26922015/93763f3b-a3ae-4e43-b413-9f1ba02170ae" width=40%> <img src="https://github.com/weIT-1st/Odya-iOS/assets/26922015/db95d588-30db-4312-ae13-6589a7d58227" width=40%>

### 관련 지라 및 위키 링크
[ODYA-197](https://weit.atlassian.net/browse/ODYA-197)

### 리뷰어에게 하고 싶은 말
커뮤니티 피드에서 몇개 테스트 해봤는데 문제는 없었습니다. 여행일지도 한번 테스트 부탁드립니당