### PR TITLE
FEAT: ODYA-195 여행일지 즐겨찾기 및 태그 삭제 

### DIFF
--- a/Odya-iOS.xcodeproj/project.pbxproj
+++ b/Odya-iOS.xcodeproj/project.pbxproj
@@ -127,6 +127,7 @@
 		3ED22F652AAE3BFD0067DE72 /* FollowHubViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ED22F642AAE3BFD0067DE72 /* FollowHubViewModel.swift */; };
 		3ED22F672AAF2FAE0067DE72 /* UserSuggestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ED22F662AAF2FAD0067DE72 /* UserSuggestion.swift */; };
 		3ED22F692AB5B3860067DE72 /* FollowUserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ED22F682AB5B3850067DE72 /* FollowUserView.swift */; };
+		3ED8DBAE2B0A1C2100D7CF7F /* JournalBookmarkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ED8DBAD2B0A1C2100D7CF7F /* JournalBookmarkManager.swift */; };
 		3EE1036B2AD483F2004EDCEB /* StarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EE1036A2AD483F2004EDCEB /* StarButton.swift */; };
 		3EE9CA1B2AB5D67A003A2E85 /* FollowRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EE9CA1A2AB5D67A003A2E85 /* FollowRouter.swift */; };
 		3EE9CA1D2AB6C44B003A2E85 /* UserRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EE9CA1C2AB6C44B003A2E85 /* UserRouter.swift */; };
@@ -293,6 +294,7 @@
 		3ED22F642AAE3BFD0067DE72 /* FollowHubViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FollowHubViewModel.swift; sourceTree = "<group>"; };
 		3ED22F662AAF2FAD0067DE72 /* UserSuggestion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSuggestion.swift; sourceTree = "<group>"; };
 		3ED22F682AB5B3850067DE72 /* FollowUserView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FollowUserView.swift; sourceTree = "<group>"; };
+		3ED8DBAD2B0A1C2100D7CF7F /* JournalBookmarkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JournalBookmarkManager.swift; sourceTree = "<group>"; };
 		3EE1036A2AD483F2004EDCEB /* StarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StarButton.swift; sourceTree = "<group>"; };
 		3EE9CA1A2AB5D67A003A2E85 /* FollowRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FollowRouter.swift; sourceTree = "<group>"; };
 		3EE9CA1C2AB6C44B003A2E85 /* UserRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserRouter.swift; sourceTree = "<group>"; };
@@ -451,6 +453,7 @@
 				07A0EC792A3F8014002D36B9 /* AppleSignInManager.swift */,
 				0708FC2C2A40D2C100D152CF /* LocationManager.swift */,
 				3E26C3812AF16790003607A8 /* ImageManager.swift */,
+				3ED8DBAD2B0A1C2100D7CF7F /* JournalBookmarkManager.swift */,
 			);
 			path = Managers;
 			sourceTree = "<group>";
@@ -1152,6 +1155,7 @@
 				3EF5499F2A42FE7A006562F8 /* TextStyles.swift in Sources */,
 				3EE9CA3F2AC94FDB003A2E85 /* MyJournalCardView.swift in Sources */,
 				3EE9CA3D2AC84D95003A2E85 /* MyJournalsView.swift in Sources */,
+				3ED8DBAE2B0A1C2100D7CF7F /* JournalBookmarkManager.swift in Sources */,
 				07AF2B192A392F0500D54780 /* LocationSearchView.swift in Sources */,
 				3EBEC3B52A6FFC3500998EC6 /* CTAButton.swift in Sources */,
 				3E26C37F2AF0E80E003607A8 /* DailyJournalViewModel.swift in Sources */,

--- a/Odya-iOS/Api/Routers/TravelJournalRouter.swift
+++ b/Odya-iOS/Api/Routers/TravelJournalRouter.swift
@@ -21,7 +21,7 @@ func checkRequestSize(_ formData:  [MultipartFormData] ) -> Void {
   print("MultipartFormData 데이터 크기: \(multipartDataSize) bytes")
 }
 
-
+// MARK: Api Request Data
 struct TravelJournalContentRequest: Codable {
     var content: String
     var placeId: String?
@@ -65,8 +65,9 @@ struct TravelJournalUpdateRequest: Codable {
     var updateTravelCompanionTotalCount: Int
 }
 
-
+// MARK: Travel Journal Enum
 enum TravelJournalRouter {
+  // 여행일지 생성
     case create(token: String,
                 title: String,
                 startDate: [Int],
@@ -78,6 +79,9 @@ enum TravelJournalRouter {
                 travelDuration: Int,
                 imagesTotalCount: Int,
                 images: [(data: Data, name: String)])
+  // 여행일지 삭제
+    case delete(token: String, journalId: Int)
+  // 여행일지 기본정보 수정
     case edit(token: String, journalId: Int,
               title: String,
               startDate: [Int],
@@ -87,6 +91,9 @@ enum TravelJournalRouter {
               travelMateNames: [String],
               travelDuration: Int,
               newTravelMatesCount: Int)
+  // 여행일지 데일리 일정 삭제
+    case deleteContent(token: String, journalId: Int, contentId: Int)
+  // 여행일지 데일리 일정 수정
     case editContent(token: String, journalId: Int, contentId: Int,
                      content: String,
                      placeId: String?,
@@ -97,19 +104,29 @@ enum TravelJournalRouter {
                      deletedImageIds: [Int],
                      newImageTotalCount: Int,
                      images: [(data: Data, name: String)])
-    case delete(token: String, journalId: Int)
-    case deleteContent(token: String, journalId: Int, contentId: Int)
+  // 함께 간 친구 삭제
+  // 태그된 사용자가 태그를 지울때... 사용되는 것 같음.. 아마도
     case deleteTravelMates(token: String, journalId: Int)
-    
+  
+  // 여행일지 아이디로 검색
+  // 해당 여행일지의 디테일 정보를 모두 가져옴
     case searchById(token: String, journalId: Int)
+  // 여행일지 목록 조회
     case getJournals(token: String, size: Int?, lastId: Int?)
+  // 내 여행일지 목록 조회
     case getMyJournals(token: String, size: Int?, lastId: Int?)
+  // 친구 여행일지 목록 조회
     case getFriendsJournals(token: String, size: Int?, lastId: Int?)
+  // 추천 여행일지 목록 조회
     case getRecommendedJournals(token: String, size: Int?, lastId: Int?)
+  // 태그된 여행일지 목록 조회
     case getTaggedJournals(token: String, size: Int?, lastId: Int?)
     
+  // 여행일지 북마크 생성(즐겨찾기 추가)
     case createBookmark(token: String, journalId: Int)
+  // 즐겨찾기된 여행일지 목록 조회
     case getBookmarkedJournals(token: String, size: Int?, lastId: Int?)
+  // 여행일지 북마크 삭제(즐겨찾기 해제)
     case deleteBookmark(token: String, journalId: Int)
 
 }

--- a/Odya-iOS/Core/Image/ImageGridView.swift
+++ b/Odya-iOS/Core/Image/ImageGridView.swift
@@ -29,8 +29,9 @@ struct ImageGridView: View {
                     AsyncImage(url: URL(string: imageUrl)) { image in
                         image
                             .resizable()
-                            .frame(width: imageSize, height: imageSize)
                             .aspectRatio(contentMode: .fill)
+                            .frame(width: imageSize, height: imageSize)
+                            .clipped()
                     } placeholder: {
                         ProgressView()
                             .frame(width: imageSize, height: imageSize * 4/3)

--- a/Odya-iOS/Core/TravelJournal/MyJournals/View/MyJournalCardView.swift
+++ b/Odya-iOS/Core/TravelJournal/MyJournals/View/MyJournalCardView.swift
@@ -200,7 +200,6 @@ struct TravelJournalSmallCardView: View {
         .b1Style()
         .lineLimit(1)
       HStack {
-//        Circle().frame(width: 24, height: 24)
         ProfileImageView(of: writer.nickname, profileData: writer.profile, size: .XS)
         Spacer()
         Text(dateString)
@@ -358,13 +357,11 @@ struct TaggedJournalCardOverlayMenuView: View {
       Button("취소") { isShowingTaggingDeletionAlert = false }
       Button("삭제") {
         isShowingTaggingDeletionAlert = false
-        // api
-        print("태그 삭제 클릭")
-//        myJournalsVM.deleteTagging(of: journalId) { success in
-//          if success {
-//            myJournalsVM.updateTaggedJournals()
-//          }
-//        }
+        myJournalsVM.deleteTagging(of: journalId) { success in
+          if success {
+            myJournalsVM.updateTaggedJournals()
+          }
+        }
       }
     } // alert
   }

--- a/Odya-iOS/Core/TravelJournal/MyJournals/View/MyJournalCardView.swift
+++ b/Odya-iOS/Core/TravelJournal/MyJournals/View/MyJournalCardView.swift
@@ -164,12 +164,14 @@ struct TravelJournalSmallCardView: View {
   var title: String
   var dateString: String
   var imageUrl: String
+  var writer: FollowUserData
 
-  init(title: String, date: Date, imageUrl: String) {
+  init(title: String, date: Date, imageUrl: String, writer: FollowUserData) {
     self.title = title
     self.dateString =
       date.dateToString(format: "yyyy.MM.dd")
     self.imageUrl = imageUrl
+    self.writer = writer
   }
 
   var body: some View {
@@ -198,7 +200,8 @@ struct TravelJournalSmallCardView: View {
         .b1Style()
         .lineLimit(1)
       HStack {
-        Circle().frame(width: 24, height: 24)
+//        Circle().frame(width: 24, height: 24)
+        ProfileImageView(of: writer.nickname, profileData: writer.profile, size: .XS)
         Spacer()
         Text(dateString)
           .detail2Style()
@@ -330,6 +333,7 @@ struct TaggedJournalCardOverlayMenuView: View {
   var isMarked: Bool {
     myJournalsVM.bookmarkedJournals.contains(where: {$0.journalId == journalId})
   }
+  @State private var isShowingTaggingDeletionAlert: Bool = false
 
   var body: some View {
     VStack {
@@ -341,13 +345,28 @@ struct TaggedJournalCardOverlayMenuView: View {
         }
         Spacer()
         Menu {
-          Button("삭제하기") {}
+          Button("삭제하기") {
+            isShowingTaggingDeletionAlert = true
+          }
         } label: {
           Image("menu-kebob")
         }
       }.padding(10)
       Spacer()
     }
+    .alert("해당 여행일지의 태그를 삭제하시겠습니까?", isPresented: $isShowingTaggingDeletionAlert) {
+      Button("취소") { isShowingTaggingDeletionAlert = false }
+      Button("삭제") {
+        isShowingTaggingDeletionAlert = false
+        // api
+        print("태그 삭제 클릭")
+//        myJournalsVM.deleteTagging(of: journalId) { success in
+//          if success {
+//            myJournalsVM.updateTaggedJournals()
+//          }
+//        }
+      }
+    } // alert
   }
 }
 

--- a/Odya-iOS/Core/TravelJournal/MyJournals/View/MyJournalCardView.swift
+++ b/Odya-iOS/Core/TravelJournal/MyJournals/View/MyJournalCardView.swift
@@ -82,17 +82,24 @@ struct RandomJounalCardView: View {
 
 /// 내 추억 뷰에서 내 여행일지를 보여주기 위한 기본 크기의 카드 뷰
 struct TravelJournalCardView: View {
+  @EnvironmentObject var myJournalsVM: MyJournalsViewModel
+  @StateObject var bookmarkManager = JournalBookmarkManager()
+  
   let cardHeight: CGFloat = 250
   let cardWidth: CGFloat = UIScreen.main.bounds.width - (GridLayout.side * 2)
 
+  let journalId: Int
   var title: String
   var travelDateString: String
   var locationString: String
   var imageUrl: String
 
-  @State private var isMarked: Bool = true
+  var isMarked: Bool {
+    myJournalsVM.bookmarkedJournals.contains(where: {$0.journalId == journalId})
+  }
 
   init(journal: TravelJournalData) {
+    self.journalId = journal.journalId
     self.title = journal.title
     self.travelDateString =
       "\(journal.travelStartDate.dateToString(format: "yyyy.MM.dd")) ~ \(journal.travelEndDate.dateToString(format: "yyyy.MM.dd"))"
@@ -107,7 +114,9 @@ struct TravelJournalCardView: View {
         url: imageUrl, width: cardWidth, height: cardHeight, cornerRadius: Radius.large)
 
       StarButton(isActive: isMarked, isYellowWhenActive: true) {
-        isMarked.toggle()
+        bookmarkManager.setBookmarkState(isMarked, journalId) { _ in
+          myJournalsVM.updateBookmarkedJournals()
+        }
       }.offset(x: cardWidth / 2 - 25, y: -(cardHeight / 2 - 25))
 
       VStack {
@@ -289,14 +298,22 @@ struct MyReviewCardView: View {
 
 /// 즐겨찾기된 여행일지 카드뷰에 오버레이 되는 메뉴 바
 struct FavoriteJournalCardOverlayMenuView: View {
-  @State private var isActive: Bool = true
+  @EnvironmentObject var myJournalsVM: MyJournalsViewModel
+  @StateObject var bookmarkManager = JournalBookmarkManager()
+  
+  let journalId: Int
+  var isMarked: Bool {
+    myJournalsVM.bookmarkedJournals.contains(where: {$0.journalId == journalId})
+  }
 
   var body: some View {
     VStack {
       HStack {
         Spacer()
-        StarButton(isActive: isActive, isYellowWhenActive: true) {
-          isActive.toggle()
+        StarButton(isActive: isMarked, isYellowWhenActive: true) {
+          bookmarkManager.setBookmarkState(isMarked, journalId) { _ in
+            myJournalsVM.updateBookmarkedJournals()
+          }
         }
       }.padding(10)
       Spacer()
@@ -306,13 +323,21 @@ struct FavoriteJournalCardOverlayMenuView: View {
 
 /// 태그된 여행일지 카드뷰에 오버레이 되는 메뉴 바
 struct TaggedJournalCardOverlayMenuView: View {
-  @State private var isActive: Bool = true
+  @EnvironmentObject var myJournalsVM: MyJournalsViewModel
+  @StateObject var bookmarkManager = JournalBookmarkManager()
+  
+  let journalId: Int
+  var isMarked: Bool {
+    myJournalsVM.bookmarkedJournals.contains(where: {$0.journalId == journalId})
+  }
 
   var body: some View {
     VStack {
       HStack {
-        StarButton(isActive: isActive, isYellowWhenActive: true) {
-          isActive.toggle()
+        StarButton(isActive: isMarked, isYellowWhenActive: true) {
+          bookmarkManager.setBookmarkState(isMarked, journalId) { _ in
+            myJournalsVM.updateBookmarkedJournals()
+          }
         }
         Spacer()
         Menu {

--- a/Odya-iOS/Core/TravelJournal/MyJournals/View/MyJournalsView.swift
+++ b/Odya-iOS/Core/TravelJournal/MyJournals/View/MyJournalsView.swift
@@ -42,13 +42,16 @@ struct MyJournalsView: View {
               
               myTravelJournalList
               
-              if !VM.bookmarkedJournals.isEmpty {
+              if VM.isBookmarkedJournalsLoading
+                  || !VM.bookmarkedJournals.isEmpty {
                 myBookmarkedTravelJournalList
               }
               
-              if !VM.taggedJournals.isEmpty {
+              if VM.isTaggedJournalsLoading
+                  || !VM.taggedJournals.isEmpty {
                 myTaggedTravelJournalList
               }
+              
               myReviewList
             }
             .padding(.horizontal, GridLayout.side)
@@ -117,6 +120,7 @@ struct MyJournalsView: View {
             true)
         ) {
           TravelJournalCardView(journal: journal)
+            .environmentObject(VM)
         }.padding(.bottom, 12)
       }
     }
@@ -130,22 +134,33 @@ struct MyJournalsView: View {
         .h4Style()
         .foregroundColor(.odya.label.normal)
         .padding(.bottom, 32)
-
-      ScrollView(.horizontal, showsIndicators: false) {
-        HStack(spacing: 10) {
-          ForEach(VM.bookmarkedJournals, id: \.id) { journal in
-            NavigationLink(
-              destination: TravelJournalDetailView(journalId: journal.journalId)
-                .navigationBarHidden(true)
-            ) {
-              TravelJournalSmallCardView(
-                title: journal.title, date: journal.travelStartDate, imageUrl: journal.mainImageUrl)
-            }.overlay {
-              FavoriteJournalCardOverlayMenuView()
-            }
-          }
+      
+      ZStack(alignment: .center) {
+        if VM.isBookmarkedJournalsLoading {
+          ProgressView()
+            .frame(height: 250)
+            .frame(maxWidth: .infinity)
         }
-      }
+        
+        else {
+          ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 10) {
+              ForEach(VM.bookmarkedJournals, id: \.id) { journal in
+                NavigationLink(
+                  destination: TravelJournalDetailView(journalId: journal.journalId)
+                    .navigationBarHidden(true)
+                ) {
+                  TravelJournalSmallCardView(
+                    title: journal.title, date: journal.travelStartDate, imageUrl: journal.mainImageUrl)
+                }.overlay {
+                  FavoriteJournalCardOverlayMenuView(journalId: journal.journalId)
+                    .environmentObject(VM)
+                }
+              } // ForEach
+            }
+          } // ScrollView
+        }
+      } // ZStack
 
     }
   }
@@ -153,29 +168,39 @@ struct MyJournalsView: View {
   // MARK: My Tagged Travel Journal List
 
   private var myTaggedTravelJournalList: some View {
-    return VStack(alignment: .leading, spacing: 0) {
+    VStack(alignment: .leading, spacing: 0) {
       Text("태그된 여행일지")
         .h4Style()
         .foregroundColor(.odya.label.normal)
         .padding(.bottom, 32)
-
-      ScrollView(.horizontal, showsIndicators: false) {
-        HStack(spacing: 10) {
-          ForEach(VM.taggedJournals, id: \.id) { journal in
-            NavigationLink(
-              destination: TravelJournalDetailView(journalId: journal.journalId)
-                .navigationBarHidden(true)
-            ) {
-              TravelJournalSmallCardView(
-                title: journal.title, date: journal.travelStartDate, imageUrl: journal.mainImageUrl)
-            }
-            .overlay {
-              TaggedJournalCardOverlayMenuView()
-            }
-          }
+      
+      ZStack(alignment: .center) {
+        if VM.isTaggedJournalsLoading {
+          ProgressView()
+            .frame(height: 250)
+            .frame(maxWidth: .infinity)
         }
-      }
-
+        
+        else {
+          ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 10) {
+              ForEach(VM.taggedJournals, id: \.id) { journal in
+                NavigationLink(
+                  destination: TravelJournalDetailView(journalId: journal.journalId)
+                    .navigationBarHidden(true)
+                ) {
+                  TravelJournalSmallCardView(
+                    title: journal.title, date: journal.travelStartDate, imageUrl: journal.mainImageUrl)
+                }
+                .overlay {
+                  TaggedJournalCardOverlayMenuView(journalId: journal.journalId)
+                    .environmentObject(VM)
+                }
+              } // ForEach
+            }
+          } // ScrollView
+        }
+      } // ZStack
     }
   }
 

--- a/Odya-iOS/Core/TravelJournal/MyJournals/View/MyJournalsView.swift
+++ b/Odya-iOS/Core/TravelJournal/MyJournals/View/MyJournalsView.swift
@@ -147,11 +147,11 @@ struct MyJournalsView: View {
             HStack(spacing: 10) {
               ForEach(VM.bookmarkedJournals, id: \.id) { journal in
                 NavigationLink(
-                  destination: TravelJournalDetailView(journalId: journal.journalId)
+                  destination: TravelJournalDetailView(journalId: journal.journalId, nickname: journal.writer.nickname)
                     .navigationBarHidden(true)
                 ) {
                   TravelJournalSmallCardView(
-                    title: journal.title, date: journal.travelStartDate, imageUrl: journal.mainImageUrl)
+                    title: journal.title, date: journal.travelStartDate, imageUrl: journal.mainImageUrl, writer: journal.writer)
                 }.overlay {
                   FavoriteJournalCardOverlayMenuView(journalId: journal.journalId)
                     .environmentObject(VM)
@@ -186,11 +186,11 @@ struct MyJournalsView: View {
             HStack(spacing: 10) {
               ForEach(VM.taggedJournals, id: \.id) { journal in
                 NavigationLink(
-                  destination: TravelJournalDetailView(journalId: journal.journalId)
+                  destination: TravelJournalDetailView(journalId: journal.journalId, nickname: journal.writer.nickname)
                     .navigationBarHidden(true)
                 ) {
                   TravelJournalSmallCardView(
-                    title: journal.title, date: journal.travelStartDate, imageUrl: journal.mainImageUrl)
+                    title: journal.title, date: journal.travelStartDate, imageUrl: journal.mainImageUrl, writer: journal.writer)
                 }
                 .overlay {
                   TaggedJournalCardOverlayMenuView(journalId: journal.journalId)

--- a/Odya-iOS/Core/TravelJournal/MyJournals/ViewModel/TravelJournalViewModel.swift
+++ b/Odya-iOS/Core/TravelJournal/MyJournals/ViewModel/TravelJournalViewModel.swift
@@ -140,6 +140,19 @@ class MyJournalsViewModel: ObservableObject {
   }
 
   // MARK: Get Bookmarked Journals
+  
+  func updateBookmarkedJournals() {
+    guard let idToken = idToken else {
+      return
+    }
+    
+    isBookmarkedJournalsLoading = false
+    hasNextBookmarkedJournals = true
+    lastIdOfBookmarkedJournals = nil
+    bookmarkedJournals = []
+    
+    getBookmarkedJournals(idToken: idToken)
+  }
 
   private func getBookmarkedJournals(idToken: String) {
     if isBookmarkedJournalsLoading || !hasNextBookmarkedJournals {

--- a/Odya-iOS/Core/TravelJournal/TravelJournalDetail/View/DailyJournalView.swift
+++ b/Odya-iOS/Core/TravelJournal/TravelJournalDetail/View/DailyJournalView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct DailyJournalView: View {
 
   @EnvironmentObject var journalDetailVM: TravelJournalDetailViewModel
-
+  
   // journal data
   let journalId: Int
   let dailyJournal: DailyJournal
@@ -55,6 +55,7 @@ struct DailyJournalView: View {
 
   var body: some View {
     VStack(spacing: 16) {
+      // date & menu bar
       HStack(spacing: 10) {
         Button(action: {
           isExpanded.toggle()
@@ -68,16 +69,18 @@ struct DailyJournalView: View {
           }.frame(height: 36)
         }
 
-        Menu {
-          Button("편집하기") {
-            print("edit")
-            journalDetailVM.editedDailyJournal = dailyJournal
+        if journalDetailVM.isMyJournal {
+          Menu {
+            Button("편집하기") {
+              print("edit")
+              journalDetailVM.editedDailyJournal = dailyJournal
+            }
+            Button("삭제하기", role: .destructive) {
+              isShowingJournalDeletionAlert = true
+            }
+          } label: {
+            Image("menu-kebob")
           }
-          Button("삭제하기", role: .destructive) {
-            isShowingJournalDeletionAlert = true
-          }
-        } label: {
-          Image("menu-kebob")
         }
       }
 

--- a/Odya-iOS/Core/TravelJournal/TravelJournalDetail/View/TravelJournalDetailView.swift
+++ b/Odya-iOS/Core/TravelJournal/TravelJournalDetail/View/TravelJournalDetailView.swift
@@ -15,12 +15,18 @@ struct TravelJournalDetailView: View {
   @StateObject var bookmarkManager = JournalBookmarkManager()
 
   let journalId: Int
+  let writerNickname: String
 
   var isBookmarked: Bool {
     guard let journal = journalDetailVM.journalDetail else {
       return false
     }
     return journal.isBookmarked
+  }
+  
+  init(journalId: Int, nickname: String = "") {
+    self.journalId = journalId
+    self.writerNickname = (MyData().nickname == nickname) ? "" : nickname
   }
   
   /// 메뉴 버튼 클릭 시에 메뉴 화면 표시 여부
@@ -133,7 +139,7 @@ struct TravelJournalDetailView: View {
   private var headerBar: some View {
     VStack {
       ZStack {
-        CustomNavigationBar(title: "")
+        CustomNavigationBar(title: writerNickname)
         HStack(spacing: 8) {
           // 바텀시트 올라와 있을 경우, 백버튼 = 바텀시트 닫기 버튼
           if bottomSheetVM.isSheetOn {
@@ -145,13 +151,15 @@ struct TravelJournalDetailView: View {
             }
           }
           Spacer()
-          StarButton(isActive: isBookmarked, isYellowWhenActive: true) {
-            bookmarkManager.setBookmarkState(isBookmarked, journalId) { newState in
-              journalDetailVM.journalDetail?.isBookmarked = newState
+          if writerNickname == "" {
+            StarButton(isActive: isBookmarked, isYellowWhenActive: true) {
+              bookmarkManager.setBookmarkState(isBookmarked, journalId) { newState in
+                journalDetailVM.journalDetail?.isBookmarked = newState
+              }
             }
-          }
-          IconButton("menu-meatballs-l") {
-            isShowingMeatballMenu = true
+            IconButton("menu-meatballs-l") {
+              isShowingMeatballMenu = true
+            }
           }
         }
         .padding(.leading, 8)

--- a/Odya-iOS/Core/TravelJournal/TravelJournalDetail/View/TravelJournalDetailView.swift
+++ b/Odya-iOS/Core/TravelJournal/TravelJournalDetail/View/TravelJournalDetailView.swift
@@ -93,6 +93,7 @@ struct TravelJournalDetailView: View {
     .onAppear {
       journalDetailVM.getJournalDetail(journalId: journalId)
       bottomSheetVM.isSheetOn = false
+      journalDetailVM.isMyJournal = writerNickname == ""
     }
     // 메뉴 버튼 클릭
     .confirmationDialog("", isPresented: $isShowingMeatballMenu) {

--- a/Odya-iOS/Core/TravelJournal/TravelJournalDetail/ViewModel/TravelJournalDetailViewModel.swift
+++ b/Odya-iOS/Core/TravelJournal/TravelJournalDetail/ViewModel/TravelJournalDetailViewModel.swift
@@ -25,6 +25,7 @@ class TravelJournalDetailViewModel: ObservableObject {
   var deletingDailyJournalId: [Int] = []
 
   @Published var journalDetail: TravelJournalDetailData? = nil
+  @Published var isMyJournal: Bool = false
   @Published var isFeedType: Bool = true
   @Published var isAllExpanded: Bool = false
   @Published var isEditViewShowing: Bool = false

--- a/Odya-iOS/Managers/JournalBookmarkManager.swift
+++ b/Odya-iOS/Managers/JournalBookmarkManager.swift
@@ -1,0 +1,130 @@
+//
+//  JournalBookmarkManager.swift
+//  Odya-iOS
+//
+//  Created by Heeoh Son on 2023/11/19.
+//
+
+import SwiftUI
+import Combine
+import CombineMoya
+import Moya
+
+class JournalBookmarkManager: ObservableObject {
+  // moya
+  private let plugin: PluginType = NetworkLoggerPlugin(configuration: .init(logOptions: .verbose))
+  private lazy var journalProvider = MoyaProvider<TravelJournalRouter>(plugins: [plugin])
+  private var subscription = Set<AnyCancellable>()
+  @Published var appDataManager = AppDataManager()
+  
+  @AppStorage("WeITAuthToken") var idToken: String?
+  
+  // loading flag
+  var isStateUpdating: Bool = false
+  
+  func setBookmarkState(_ isBookmarked: Bool, _ journalId: Int,
+                       completion: @escaping (Bool) -> Void) {
+    if isBookmarked {
+      deleteBookmark(of: journalId) { success in
+        completion(!success)
+      }
+    } else {
+      createBookmark(of: journalId) { success in
+        completion(success)
+      }
+    }
+  }
+  
+  private func createBookmark(of journalId: Int,
+                      completion: @escaping (Bool) -> Void) {
+    guard let idToken = idToken else {
+      return
+    }
+    
+    if isStateUpdating {
+      return
+    }
+    
+    isStateUpdating = true
+    journalProvider.requestPublisher(.createBookmark(token: idToken, journalId: journalId))
+      .filterSuccessfulStatusCodes()
+      .sink { apiCompletion in
+        switch apiCompletion {
+        case .finished:
+          self.isStateUpdating = false
+          completion(true)
+        case .failure(let error):
+          self.isStateUpdating = false
+
+          guard let apiError = try? error.response?.map(ErrorData.self) else {
+            // error data decoding error handling
+            print("createBookmark - ErrorData decoding error")
+            completion(false)
+            return
+          }
+
+          if apiError.code == -11000 {
+            self.appDataManager.refreshToken { success in
+              // token error handling
+              if success {
+                self.createBookmark(of: journalId) { _ in }
+                return
+              }
+            }
+          }
+          
+          // other api error handling
+          print("createBookmark - something error")
+          completion(false)
+        }
+      } receiveValue: { _ in }
+      .store(in: &subscription)
+  }
+  
+  private func deleteBookmark(of journalId: Int,
+                      completion: @escaping (Bool) -> Void) {
+    guard let idToken = idToken else {
+      return
+    }
+    
+    if isStateUpdating {
+      return
+    }
+    
+    isStateUpdating = true
+    journalProvider.requestPublisher(.deleteBookmark(token: idToken, journalId: journalId))
+      .filterSuccessfulStatusCodes()
+      .sink { apiCompletion in
+        switch apiCompletion {
+        case .finished:
+          self.isStateUpdating = false
+          completion(true)
+        case .failure(let error):
+          self.isStateUpdating = false
+
+          guard let apiError = try? error.response?.map(ErrorData.self) else {
+            // error data decoding error handling
+            print("deleteBookmark - ErrorData decoding error")
+            completion(false)
+            return
+          }
+
+          if apiError.code == -11000 {
+            self.appDataManager.refreshToken { success in
+              // token error handling
+              if success {
+                self.deleteBookmark(of: journalId) { _ in }
+                return
+              }
+            }
+          }
+          
+          // other api error handling
+          print("deleteBookmark - something error")
+          completion(false)
+        }
+      } receiveValue: { _ in }
+      .store(in: &subscription)
+  }
+  
+}


### PR DESCRIPTION
### 개요
- 여행일지 즐겨찾기 버튼 활성화
- 태그된 여행일지 삭제하기 기능 추가
- 타인의 여행일지인 경우 뷰 변경 (닉네임 보이기 + 메뉴 버튼 숨기기)

### 변경사항
- 즐겨찾기 버튼 활성화
    - 내 추억 뷰에서 즐겨찾기 추가/해제 가능 -> 즐겨찾는 여행일지 뷰 업데이트됨
    - 여행일지 디테일 뷰에서 즐겨찾기 추가/해제 가능 
- 태그된 여행일지 삭제 가능 (함께 간 친구 삭제)
    - 삭제 시 태그된 여행일지 뷰 업데이트됨
- 즐겨찾는 여행일지 & 태그된 여행일지 작성자 프로필 뷰 추가
- 타인의 여행일지인 경우 뷰 변경 
    - 닉네임 보이기 + 메뉴 버튼 숨기기
- 이미지 그리드 뷰 가로로 늘어나는 오류 수정

### 관련 지라 및 위키 링크
- [ODYA-195](https://weit.atlassian.net/browse/ODYA-195)

### 리뷰어에게 하고 싶은 말
- 즐겨찾기 & 태그 
<img width="485" alt="스크린샷 2023-11-23 오전 8 45 13" src="https://github.com/weIT-1st/Odya-iOS/assets/70556633/2674cc1d-eb15-4f1a-bbd9-52daa9028f37">

- 내 여행일지
<img width="485" alt="스크린샷 2023-11-23 오전 8 44 59" src="https://github.com/weIT-1st/Odya-iOS/assets/70556633/f930f1e1-c491-423a-b5e7-987b95b77983">

- 타인의 여행일지
<img width="485" alt="스크린샷 2023-11-23 오전 8 45 27" src="https://github.com/weIT-1st/Odya-iOS/assets/70556633/89ef522a-2ff3-47fa-978c-f8c10d3fb799">

