### PR TITLE
FEAT: ODYA-226 여행일지 자잘한 오류 수정

### DIFF
--- a/Odya-iOS.xcodeproj/project.pbxproj
+++ b/Odya-iOS.xcodeproj/project.pbxproj
@@ -107,6 +107,9 @@
 		3E2F29742B2AE8CE00FF5357 /* BookmarkedJournalListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E2F29732B2AE8CE00FF5357 /* BookmarkedJournalListView.swift */; };
 		3E2F29762B2AE98F00FF5357 /* TravelJournalBookmarkRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E2F29752B2AE98F00FF5357 /* TravelJournalBookmarkRouter.swift */; };
 		3E2F29782B2AFCF000FF5357 /* BookmarkedJournalListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E2F29772B2AFCF000FF5357 /* BookmarkedJournalListViewModel.swift */; };
+		3E2F297A2B2B173800FF5357 /* TaggedJournalListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E2F29792B2B173800FF5357 /* TaggedJournalListView.swift */; };
+		3E2F297C2B2B17DB00FF5357 /* TaggedJournalListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E2F297B2B2B17DB00FF5357 /* TaggedJournalListViewModel.swift */; };
+		3E2F297E2B2B183800FF5357 /* TravelJournalTagRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E2F297D2B2B183800FF5357 /* TravelJournalTagRouter.swift */; };
 		3E36EC732A2B596C006008E5 /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E36EC722A2B596C006008E5 /* MainView.swift */; };
 		3E3EC3AD2A388AA5002BF519 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = 3E3EC3AC2A388AA5002BF519 /* Alamofire */; };
 		3E3EC3B02A388AC0002BF519 /* SwiftyJSON in Frameworks */ = {isa = PBXBuildFile; productRef = 3E3EC3AF2A388AC0002BF519 /* SwiftyJSON */; };
@@ -317,6 +320,9 @@
 		3E2F29732B2AE8CE00FF5357 /* BookmarkedJournalListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkedJournalListView.swift; sourceTree = "<group>"; };
 		3E2F29752B2AE98F00FF5357 /* TravelJournalBookmarkRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TravelJournalBookmarkRouter.swift; sourceTree = "<group>"; };
 		3E2F29772B2AFCF000FF5357 /* BookmarkedJournalListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkedJournalListViewModel.swift; sourceTree = "<group>"; };
+		3E2F29792B2B173800FF5357 /* TaggedJournalListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaggedJournalListView.swift; sourceTree = "<group>"; };
+		3E2F297B2B2B17DB00FF5357 /* TaggedJournalListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaggedJournalListViewModel.swift; sourceTree = "<group>"; };
+		3E2F297D2B2B183800FF5357 /* TravelJournalTagRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TravelJournalTagRouter.swift; sourceTree = "<group>"; };
 		3E36EC722A2B596C006008E5 /* MainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainView.swift; sourceTree = "<group>"; };
 		3E414B2B2AD6941C00034FBB /* AppDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDataManager.swift; sourceTree = "<group>"; };
 		3E414B2D2ADB283B00034FBB /* TravelJournalRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TravelJournalRouter.swift; sourceTree = "<group>"; };
@@ -877,6 +883,7 @@
 				3EB938162AF795A60041FE5B /* NoJournalView.swift */,
 				3EE9CA3E2AC94FDA003A2E85 /* MyJournalCardView.swift */,
 				3E2F29732B2AE8CE00FF5357 /* BookmarkedJournalListView.swift */,
+				3E2F29792B2B173800FF5357 /* TaggedJournalListView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -886,6 +893,7 @@
 			children = (
 				3E414B342ADFDE8500034FBB /* TravelJournalViewModel.swift */,
 				3E2F29772B2AFCF000FF5357 /* BookmarkedJournalListViewModel.swift */,
+				3E2F297B2B2B17DB00FF5357 /* TaggedJournalListViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -1079,6 +1087,7 @@
 				19EBA7562AB16BDE000ABBE5 /* TermsRouter.swift */,
 				3EE9CA1A2AB5D67A003A2E85 /* FollowRouter.swift */,
 				3E414B2D2ADB283B00034FBB /* TravelJournalRouter.swift */,
+				3E2F297D2B2B183800FF5357 /* TravelJournalTagRouter.swift */,
 				3E2F29752B2AE98F00FF5357 /* TravelJournalBookmarkRouter.swift */,
 				3EE9CA1C2AB6C44B003A2E85 /* UserRouter.swift */,
 				07589E6F2AF023C200867FAD /* TopicRouter.swift */,
@@ -1292,6 +1301,7 @@
 				3EBEC3A22A6C38EC00998EC6 /* ComponetsTestView.swift in Sources */,
 				3E075C912B230A1C0093CACD /* PofileInfoSection.swift in Sources */,
 				3ED22F652AAE3BFD0067DE72 /* FollowHubViewModel.swift in Sources */,
+				3E2F297A2B2B173800FF5357 /* TaggedJournalListView.swift in Sources */,
 				3EF54A092A5BE9DA006562F8 /* ApiService.swift in Sources */,
 				192ADAA12B0D8D7E00BD480E /* ReportView.swift in Sources */,
 				19EBA7672AB42D1B000ABBE5 /* FeedCommentView.swift in Sources */,
@@ -1321,7 +1331,9 @@
 				3E414B2E2ADB283B00034FBB /* TravelJournalRouter.swift in Sources */,
 				3E414B2C2AD6941C00034FBB /* AppDataManager.swift in Sources */,
 				3EB938152AF531780041FE5B /* AsyncImageView.swift in Sources */,
+				3E2F297C2B2B17DB00FF5357 /* TaggedJournalListViewModel.swift in Sources */,
 				3E0588FD2A276E64005C29D9 /* KakaoLoginButton.swift in Sources */,
+				3E2F297E2B2B183800FF5357 /* TravelJournalTagRouter.swift in Sources */,
 				07310DB62A7286380047E972 /* ReviewApiService.swift in Sources */,
 				3E0589032A276E8C005C29D9 /* SceneDelegate.swift in Sources */,
 				3ED22F3A2A9853830067DE72 /* TravelMateSelectorView.swift in Sources */,

--- a/Odya-iOS.xcodeproj/project.pbxproj
+++ b/Odya-iOS.xcodeproj/project.pbxproj
@@ -104,6 +104,9 @@
 		3E26C3822AF16790003607A8 /* ImageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E26C3812AF16790003607A8 /* ImageManager.swift */; };
 		3E26C3842AF394AF003607A8 /* OffsettableScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E26C3832AF394AF003607A8 /* OffsettableScrollView.swift */; };
 		3E26C3862AF3956F003607A8 /* TravelMatesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E26C3852AF3956F003607A8 /* TravelMatesView.swift */; };
+		3E2F29742B2AE8CE00FF5357 /* BookmarkedJournalListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E2F29732B2AE8CE00FF5357 /* BookmarkedJournalListView.swift */; };
+		3E2F29762B2AE98F00FF5357 /* TravelJournalBookmarkRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E2F29752B2AE98F00FF5357 /* TravelJournalBookmarkRouter.swift */; };
+		3E2F29782B2AFCF000FF5357 /* BookmarkedJournalListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E2F29772B2AFCF000FF5357 /* BookmarkedJournalListViewModel.swift */; };
 		3E36EC732A2B596C006008E5 /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E36EC722A2B596C006008E5 /* MainView.swift */; };
 		3E3EC3AD2A388AA5002BF519 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = 3E3EC3AC2A388AA5002BF519 /* Alamofire */; };
 		3E3EC3B02A388AC0002BF519 /* SwiftyJSON in Frameworks */ = {isa = PBXBuildFile; productRef = 3E3EC3AF2A388AC0002BF519 /* SwiftyJSON */; };
@@ -311,6 +314,9 @@
 		3E26C3812AF16790003607A8 /* ImageManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageManager.swift; sourceTree = "<group>"; };
 		3E26C3832AF394AF003607A8 /* OffsettableScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OffsettableScrollView.swift; sourceTree = "<group>"; };
 		3E26C3852AF3956F003607A8 /* TravelMatesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TravelMatesView.swift; sourceTree = "<group>"; };
+		3E2F29732B2AE8CE00FF5357 /* BookmarkedJournalListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkedJournalListView.swift; sourceTree = "<group>"; };
+		3E2F29752B2AE98F00FF5357 /* TravelJournalBookmarkRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TravelJournalBookmarkRouter.swift; sourceTree = "<group>"; };
+		3E2F29772B2AFCF000FF5357 /* BookmarkedJournalListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkedJournalListViewModel.swift; sourceTree = "<group>"; };
 		3E36EC722A2B596C006008E5 /* MainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainView.swift; sourceTree = "<group>"; };
 		3E414B2B2AD6941C00034FBB /* AppDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDataManager.swift; sourceTree = "<group>"; };
 		3E414B2D2ADB283B00034FBB /* TravelJournalRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TravelJournalRouter.swift; sourceTree = "<group>"; };
@@ -870,6 +876,7 @@
 				3EE9CA3C2AC84D95003A2E85 /* MyJournalsView.swift */,
 				3EB938162AF795A60041FE5B /* NoJournalView.swift */,
 				3EE9CA3E2AC94FDA003A2E85 /* MyJournalCardView.swift */,
+				3E2F29732B2AE8CE00FF5357 /* BookmarkedJournalListView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -878,6 +885,7 @@
 			isa = PBXGroup;
 			children = (
 				3E414B342ADFDE8500034FBB /* TravelJournalViewModel.swift */,
+				3E2F29772B2AFCF000FF5357 /* BookmarkedJournalListViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -1071,6 +1079,7 @@
 				19EBA7562AB16BDE000ABBE5 /* TermsRouter.swift */,
 				3EE9CA1A2AB5D67A003A2E85 /* FollowRouter.swift */,
 				3E414B2D2ADB283B00034FBB /* TravelJournalRouter.swift */,
+				3E2F29752B2AE98F00FF5357 /* TravelJournalBookmarkRouter.swift */,
 				3EE9CA1C2AB6C44B003A2E85 /* UserRouter.swift */,
 				07589E6F2AF023C200867FAD /* TopicRouter.swift */,
 				195BF2F62ACE525A00E4FEDD /* CommunityRouter.swift */,
@@ -1256,6 +1265,7 @@
 				3E26C3772AF0E7EC003607A8 /* DailyJournalView.swift in Sources */,
 				3ED22F632AADBC100067DE72 /* FollowHubView.swift in Sources */,
 				0732948A2A2C9975008E1026 /* UserDefaults.swift in Sources */,
+				3E2F29742B2AE8CE00FF5357 /* BookmarkedJournalListView.swift in Sources */,
 				3ED22F442AAA355B0067DE72 /* DailyJournalEditViewModel.swift in Sources */,
 				19E212A82B06F376003155C0 /* ReportRouter.swift in Sources */,
 				197C29AD2B171EAE00E6D670 /* FeedUserSearchView.swift in Sources */,
@@ -1327,6 +1337,7 @@
 				197C29AF2B17227500E6D670 /* FeedUserSearchViewModel.swift in Sources */,
 				3E075C932B23123F0093CACD /* CounterSection.swift in Sources */,
 				3EBEC3AF2A6E74DE00998EC6 /* ButtonStyles.swift in Sources */,
+				3E2F29762B2AE98F00FF5357 /* TravelJournalBookmarkRouter.swift in Sources */,
 				3E26C3862AF3956F003607A8 /* TravelMatesView.swift in Sources */,
 				3ED22F3E2A98D7070067DE72 /* Follow.swift in Sources */,
 				3EE9CA352AC3C2E8003A2E85 /* TravelJournal.swift in Sources */,
@@ -1356,6 +1367,7 @@
 				3E26C3822AF16790003607A8 /* ImageManager.swift in Sources */,
 				3E414B332ADC5D7F00034FBB /* DailyJournalComposeView.swift in Sources */,
 				3E800EC32A3E15D9001EA4C4 /* ImageGridView.swift in Sources */,
+				3E2F29782B2AFCF000FF5357 /* BookmarkedJournalListViewModel.swift in Sources */,
 				3EE9CA332AC3BD46003A2E85 /* ModalBackground.swift in Sources */,
 				078496412A84F5FE00A490E3 /* FeedView.swift in Sources */,
 				3E26C37E2AF0E80E003607A8 /* TravelJournalDetailViewModel.swift in Sources */,

--- a/Odya-iOS/Api/Routers/AuthRouter.swift
+++ b/Odya-iOS/Api/Routers/AuthRouter.swift
@@ -5,116 +5,119 @@
 //  Created by Heeoh Son on 2023/07/10.
 //
 
-import Foundation
 import Alamofire
+import Foundation
 
 // 인증 라우터
 // 회원가입(애플, 카카오)
 enum AuthRouter: URLRequestConvertible {
-    case appleLogin(idToken: String)
-    case kakaoLogin(accessToken: String)
-    case appleRegister(idToken: String,
-                       email: String?,
-                       phoneNumber: String?,
-                       nickname: String,
-                       gender: String,
-                       birthday: [Int],
-                       termsIdList: [Int])
-    case kakaoRegister(username: String,
-                       email: String?,
-                       phoneNumber: String?,
-                       nickname: String,
-                       gender: String,
-                       birthday: [Int],
-                       termsIdList: [Int])
-    case validateNickname(value: String)
-    case validateEmail(value: String)
-    case validatePhonenumber(value: String)
-    
-    var baseURL: URL {
-        return URL(string: ApiClient.BASE_URL)!
+  case appleLogin(idToken: String)
+  case kakaoLogin(accessToken: String)
+  case appleRegister(
+    idToken: String,
+    email: String?,
+    phoneNumber: String?,
+    nickname: String,
+    gender: String,
+    birthday: [Int],
+    termsIdList: [Int])
+  case kakaoRegister(
+    username: String,
+    email: String?,
+    phoneNumber: String?,
+    nickname: String,
+    gender: String,
+    birthday: [Int],
+    termsIdList: [Int])
+  case validateNickname(value: String)
+  case validateEmail(value: String)
+  case validatePhonenumber(value: String)
+
+  var baseURL: URL {
+    return URL(string: ApiClient.BASE_URL)!
+  }
+
+  var endPoint: String {
+    switch self {
+    case .appleLogin:
+      return "/api/v1/auth/login/apple"
+    case .kakaoLogin:
+      return "/api/v1/auth/login/kakao"
+    case .appleRegister:
+      return "/api/v1/auth/register/apple"
+    case .kakaoRegister:
+      return "/api/v1/auth/register/kakao"
+    case .validateNickname:
+      return "/api/v1/auth/validate/nickname"
+    case .validateEmail:
+      return "/api/v1/auth/validate/email"
+    case .validatePhonenumber:
+      return "/api/v1/auth/validate/phone-number"
     }
-    
-    var endPoint: String {
-        switch self {
-        case .appleLogin:
-            return "/api/v1/auth/login/apple"
-        case .kakaoLogin:
-            return "/api/v1/auth/login/kakao"
-        case .appleRegister:
-            return "/api/v1/auth/register/apple"
-        case .kakaoRegister:
-            return "/api/v1/auth/register/kakao"
-        case .validateNickname:
-            return "/api/v1/auth/validate/nickname"
-        case .validateEmail:
-            return "/api/v1/auth/validate/email"
-        case .validatePhonenumber:
-            return "/api/v1/auth/validate/phone-number"
-        }
+  }
+
+  var method: HTTPMethod {
+    switch self {
+    case .validateNickname, .validateEmail, .validatePhonenumber:
+      return .get
+    default:
+      return .post
     }
-    
-    var method: HTTPMethod {
-        switch self {
-        case .validateNickname, .validateEmail, .validatePhonenumber:
-            return .get
-        default:
-            return .post
-        }
+  }
+
+  var parameters: Parameters {
+    switch self {
+    case let .appleLogin(idToken):
+      let params: Parameters = ["idToken": idToken]
+      return params
+    case let .kakaoLogin(accessToken):
+      let params: Parameters = ["accessToken": accessToken]
+      return params
+    case let .appleRegister(idToken, email, phoneNumber, nickname, gender, birthday, termsIdList):
+      var params = Parameters()
+      params["idToken"] = idToken
+      params["email"] = email
+      params["phoneNumber"] = phoneNumber
+      params["nickname"] = nickname
+      params["gender"] = gender
+      params["birthday"] = birthday
+      params["termsIdList"] = termsIdList
+      return params
+    case let .kakaoRegister(username, email, phoneNumber, nickname, gender, birthday, termsIdList):
+      var params = Parameters()
+      params["username"] = username
+      params["email"] = email
+      params["phoneNumber"] = phoneNumber
+      params["nickname"] = nickname
+      params["gender"] = gender
+      params["birthday"] = birthday
+      params["termsIdList"] = termsIdList
+      return params
+    case .validateNickname(let value), .validateEmail(let value), .validatePhonenumber(let value):
+      return ["value": value]
     }
-    
-    var parameters: Parameters {
-        switch self {
-        case let .appleLogin(idToken):
-            let params: Parameters = ["idToken" : idToken]
-            return params
-        case let .kakaoLogin(accessToken):
-            let params: Parameters = ["accessToken" : accessToken]
-            return params
-        case let .appleRegister(idToken, email, phoneNumber, nickname, gender, birthday, termsIdList):
-            var params = Parameters()
-            params["idToken"] = idToken
-            params["email"] = email
-            params["phoneNumber"] = phoneNumber
-            params["nickname"] = nickname
-            params["gender"] = gender
-            params["birthday"] = birthday
-            params["termsIdList"] = termsIdList
-            return params
-        case let .kakaoRegister(username, email, phoneNumber, nickname, gender, birthday, termsIdList):
-            var params = Parameters()
-            params["username"] = username
-            params["email"] = email
-            params["phoneNumber"] = phoneNumber
-            params["nickname"] = nickname
-            params["gender"] = gender
-            params["birthday"] = birthday
-            params["termsIdList"] = termsIdList
-            return params
-        case .validateNickname(let value), .validateEmail(let value), .validatePhonenumber(let value):
-            return ["value": value]
-        }
+  }
+
+  func asURLRequest() throws -> URLRequest {
+    var url: URL
+    switch self {
+    case .validateNickname, .validateEmail, .validatePhonenumber:
+      var urlComponents = URLComponents(
+        url: baseURL.appendingPathComponent(endPoint), resolvingAgainstBaseURL: true)!
+      urlComponents.queryItems = parameters.map { URLQueryItem(name: $0.key, value: "\($0.value)") }
+      url = urlComponents.url!
+    default:
+      url = baseURL.appendingPathComponent(endPoint)
     }
-    
-    func asURLRequest() throws -> URLRequest {
-        var url: URL
-        switch self {
-        case .validateNickname, .validateEmail, .validatePhonenumber:
-            var urlComponents = URLComponents(url: baseURL.appendingPathComponent(endPoint), resolvingAgainstBaseURL: true)!
-                    urlComponents.queryItems = parameters.map { URLQueryItem(name: $0.key, value: "\($0.value)") }
-            url = urlComponents.url!
-        default:
-            url = baseURL.appendingPathComponent(endPoint)
-        }
-        print(url)
-        
-        var request = URLRequest(url: url)
-        request.method = method
-        if request.method == .post {
-            request.httpBody = try JSONEncoding.default.encode(request, with: parameters).httpBody
-        }
-        
-        return request
+    print(url)
+
+    var request = URLRequest(url: url)
+    request.method = method
+    if request.method == .post {
+      request.httpBody = try JSONEncoding.default.encode(request, with: parameters).httpBody
     }
-    
+
+    return request
+  }
+
 }

--- a/Odya-iOS/Api/Routers/CommunityCommentRouter.swift
+++ b/Odya-iOS/Api/Routers/CommunityCommentRouter.swift
@@ -23,7 +23,7 @@ extension CommunityCommentRouter: TargetType, AccessTokenAuthorizable {
   var baseURL: URL {
     return URL(string: ApiClient.BASE_URL)!
   }
-  
+
   var path: String {
     switch self {
     case .createComment(let communityId, _):
@@ -36,7 +36,7 @@ extension CommunityCommentRouter: TargetType, AccessTokenAuthorizable {
       return "/api/v1/communities/\(communityId)/comments/\(commentId)"
     }
   }
-  
+
   var method: Moya.Method {
     switch self {
     case .createComment:
@@ -49,41 +49,41 @@ extension CommunityCommentRouter: TargetType, AccessTokenAuthorizable {
       return .delete
     }
   }
-  
+
   var task: Moya.Task {
     switch self {
     case .createComment(_, let content):
       var params: [String: Any] = [:]
       params["content"] = content
       return .requestParameters(parameters: params, encoding: JSONEncoding.prettyPrinted)
-      
+
     case .getComment(_, let size, let lastId):
       var params: [String: Any] = [:]
       params["size"] = size
       params["lastId"] = lastId
       return .requestParameters(parameters: params, encoding: URLEncoding.queryString)
-      
+
     case .patchComment(_, _, let content):
       var params: [String: Any] = [:]
       params["content"] = content
       return .requestParameters(parameters: params, encoding: JSONEncoding.prettyPrinted)
-      
+
     case .deleteComment:
       return .requestPlain
     }
   }
-  
-  var headers: [String : String]? {
+
+  var headers: [String: String]? {
     switch self {
     default:
       return ["Content-type": "application/json"]
     }
   }
-  
+
   var authorizationType: Moya.AuthorizationType? {
     return .bearer
   }
-  
+
   var validationType: ValidationType {
     return .successCodes
   }

--- a/Odya-iOS/Api/Routers/CommunityLikeRouter.swift
+++ b/Odya-iOS/Api/Routers/CommunityLikeRouter.swift
@@ -17,7 +17,7 @@ extension CommunityLikeRouter: TargetType, AccessTokenAuthorizable {
   var baseURL: URL {
     return URL(string: ApiClient.BASE_URL)!
   }
-  
+
   var path: String {
     switch self {
     case .createLike(let communityId):
@@ -26,7 +26,7 @@ extension CommunityLikeRouter: TargetType, AccessTokenAuthorizable {
       return "/api/v1/communities/\(communityId)/likes"
     }
   }
-  
+
   var method: Moya.Method {
     switch self {
     case .createLike:
@@ -35,19 +35,19 @@ extension CommunityLikeRouter: TargetType, AccessTokenAuthorizable {
       return .delete
     }
   }
-  
+
   var task: Moya.Task {
     return .requestPlain
   }
-  
-  var headers: [String : String]? {
+
+  var headers: [String: String]? {
     return ["Content-type": "application/json"]
   }
-  
+
   var authorizationType: Moya.AuthorizationType? {
     return .bearer
   }
-  
+
   var validationType: ValidationType {
     return .successCodes
   }

--- a/Odya-iOS/Api/Routers/CommunityRouter.swift
+++ b/Odya-iOS/Api/Routers/CommunityRouter.swift
@@ -10,7 +10,9 @@ import Moya
 
 enum CommunityRouter {
   // 1. 생성
-  case createCommunity(content: String, visibility: String, placeId: String?, travelJournalId: Int?, topicId: Int?, images: [(data: Data, imageName: String)])
+  case createCommunity(
+    content: String, visibility: String, placeId: String?, travelJournalId: Int?, topicId: Int?,
+    images: [(data: Data, imageName: String)])
   // 2. 상세 조회
   case getCommunityDetail(communityId: Int)
   // 3. 전체 목록 조회
@@ -24,7 +26,9 @@ enum CommunityRouter {
   // 7. 좋아요 누른 목록 조회
   // 8. 댓글 단 목록 조회
   // 9. 수정
-  case updateCommunity(communityId: Int, content: String, visibility: String, placeId: String?, travelJournalId: Int?, topicId: Int?, deleteImageIds: [Int]?, updateImages: [(data: Data, imageName: String)])
+  case updateCommunity(
+    communityId: Int, content: String, visibility: String, placeId: String?, travelJournalId: Int?,
+    topicId: Int?, deleteImageIds: [Int]?, updateImages: [(data: Data, imageName: String)])
   // 10. 삭제
   case deleteCommunity(communityId: Int)
 }
@@ -33,7 +37,7 @@ extension CommunityRouter: TargetType, AccessTokenAuthorizable {
   var baseURL: URL {
     return URL(string: ApiClient.BASE_URL)!
   }
-  
+
   var path: String {
     switch self {
     case .createCommunity:
@@ -54,10 +58,11 @@ extension CommunityRouter: TargetType, AccessTokenAuthorizable {
       return "/api/v1/communities/\(communityId)"
     }
   }
-  
+
   var method: Moya.Method {
     switch self {
-    case .getCommunityDetail, .getAllCommunity, .getMyCommunity, .getFriendsCommunity, .getAllCommunityByTopic:
+    case .getCommunityDetail, .getAllCommunity, .getMyCommunity, .getFriendsCommunity,
+      .getAllCommunityByTopic:
       return .get
     case .createCommunity:
       return .post
@@ -67,10 +72,11 @@ extension CommunityRouter: TargetType, AccessTokenAuthorizable {
       return .delete
     }
   }
-  
+
   var task: Moya.Task {
     switch self {
-    case .createCommunity(let content, let visibility, let placeId, let travelJournalId, let topicId, let images):
+    case .createCommunity(
+      let content, let visibility, let placeId, let travelJournalId, let topicId, let images):
       var formData = [MultipartFormData]()
       var body: [String: Any] = [:]
       body["content"] = content
@@ -79,9 +85,15 @@ extension CommunityRouter: TargetType, AccessTokenAuthorizable {
       body["travelJournalId"] = travelJournalId
       body["topicId"] = topicId
       let encodedBody = try? JSONSerialization.data(withJSONObject: body)
-      formData.append(MultipartFormData(provider: .data(encodedBody ?? Data()), name: "community", fileName: "community", mimeType: "application/json"))
+      formData.append(
+        MultipartFormData(
+          provider: .data(encodedBody ?? Data()), name: "community", fileName: "community",
+          mimeType: "application/json"))
       for image in images {
-        formData.append(MultipartFormData(provider: .data(image.data), name: "community-content-image", fileName: "\(image.imageName).webp", mimeType: "image/webp"))
+        formData.append(
+          MultipartFormData(
+            provider: .data(image.data), name: "community-content-image",
+            fileName: "\(image.imageName).webp", mimeType: "image/webp"))
       }
       return .uploadMultipart(formData)
     case .getCommunityDetail:
@@ -110,7 +122,9 @@ extension CommunityRouter: TargetType, AccessTokenAuthorizable {
       params["lastId"] = lastId
       params["sortType"] = sortType
       return .requestParameters(parameters: params, encoding: URLEncoding.queryString)
-    case .updateCommunity(_, let content, let visibility, let placeId, let travelJournalId, let topicId, let deleteImageIds, let updateImages):
+    case .updateCommunity(
+      _, let content, let visibility, let placeId, let travelJournalId, let topicId,
+      let deleteImageIds, let updateImages):
       var formData = [MultipartFormData]()
       var body: [String: Any] = [:]
       body["content"] = content
@@ -120,27 +134,33 @@ extension CommunityRouter: TargetType, AccessTokenAuthorizable {
       body["topicId"] = topicId
       body["deleteCommunityContentImageIds"] = deleteImageIds
       let encodedBody = try? JSONSerialization.data(withJSONObject: body)
-      formData.append(MultipartFormData(provider: .data(encodedBody ?? Data()), name: "update-community", fileName: "community", mimeType: "application/json"))
+      formData.append(
+        MultipartFormData(
+          provider: .data(encodedBody ?? Data()), name: "update-community", fileName: "community",
+          mimeType: "application/json"))
       for image in updateImages {
-        formData.append(MultipartFormData(provider: .data(image.data), name: "update-community-content-image", fileName: "\(image.imageName).webp", mimeType: "image/webp"))
+        formData.append(
+          MultipartFormData(
+            provider: .data(image.data), name: "update-community-content-image",
+            fileName: "\(image.imageName).webp", mimeType: "image/webp"))
       }
       return .uploadMultipart(formData)
     case .deleteCommunity:
       return .requestPlain
     }
   }
-  
+
   var headers: [String: String]? {
     switch self {
     default:
       return ["Content-type": "application/json"]
     }
   }
-  
+
   var authorizationType: Moya.AuthorizationType? {
     return .bearer
   }
-  
+
   var validationType: ValidationType {
     return .successCodes
   }

--- a/Odya-iOS/Api/Routers/FollowRouter.swift
+++ b/Odya-iOS/Api/Routers/FollowRouter.swift
@@ -9,17 +9,17 @@ import Foundation
 import Moya
 
 enum FollowSortingType {
-    case oldest
-    case latest
-    
-    func toString() -> String {
-        switch self {
-        case .latest:
-            return "LATEST"
-        case .oldest:
-            return "OLDEST"
-        }
+  case oldest
+  case latest
+
+  func toString() -> String {
+    switch self {
+    case .latest:
+      return "LATEST"
+    case .oldest:
+      return "OLDEST"
     }
+  }
 }
 
 enum FollowRouter {
@@ -30,26 +30,31 @@ enum FollowRouter {
   // 팔로워 팔로잉 수 가져오기
   case count(userID: Int)
   // 팔로잉 리스트 가져오기
-  case getFollowing(userID: Int,
-                    page: Int,
-                    size: Int,
-                    sortType: FollowSortingType)
+  case getFollowing(
+    userID: Int,
+    page: Int,
+    size: Int,
+    sortType: FollowSortingType)
   // 팔로워 리스트 가져오기
-  case getFollower(userID: Int,
-                   page: Int,
-                   size: Int,
-                   sortType: FollowSortingType)
+  case getFollower(
+    userID: Int,
+    page: Int,
+    size: Int,
+    sortType: FollowSortingType)
   // 닉네임으로 팔로잉 친구 찾기
-  case searchFollowingByNickname(size: Int? = nil,
-                                 nickname: String,
-                                 lastID: Int? = nil)
+  case searchFollowingByNickname(
+    size: Int? = nil,
+    nickname: String,
+    lastID: Int? = nil)
   // 닉네임으로 팔로워 친구 찾기
-  case searchFollowerByNickname(size: Int? = nil,
-                                nickname: String,
-                                lastID: Int? = nil)
+  case searchFollowerByNickname(
+    size: Int? = nil,
+    nickname: String,
+    lastID: Int? = nil)
   // 알 수도 있는 친구
-  case suggestUser(size: Int,
-                   lastID: Int? = nil)
+  case suggestUser(
+    size: Int,
+    lastID: Int? = nil)
   // 해당 장소에 방문한 친구 가져오기
   case getVisitingUser(placeID: String)
 }
@@ -58,13 +63,13 @@ extension FollowRouter: TargetType, AccessTokenAuthorizable {
   var baseURL: URL {
     return URL(string: ApiClient.BASE_URL)!
   }
-  
+
   var path: String {
     switch self {
     case .create, .delete:
       return "/api/v1/follows"
     case let .count(userID):
-      return  "/api/v1/follows/\(userID)/counts"
+      return "/api/v1/follows/\(userID)/counts"
     case let .getFollowing(userID, _, _, _):
       return "/api/v1/follows/\(userID)/followings"
     case let .getFollower(userID, _, _, _):
@@ -79,7 +84,7 @@ extension FollowRouter: TargetType, AccessTokenAuthorizable {
       return "/api/v1/follows/" + placeID
     }
   }
-  
+
   var method: Moya.Method {
     switch self {
     case .create:
@@ -90,19 +95,19 @@ extension FollowRouter: TargetType, AccessTokenAuthorizable {
       return .get
     }
   }
-  
+
   var task: Moya.Task {
     switch self {
     case let .create(followingID),
       let .delete(followingID):
-      let params = ["followingId" : followingID]
+      let params = ["followingId": followingID]
       return .requestParameters(parameters: params, encoding: JSONEncoding.default)
     case let .getFollowing(_, page, size, sortType),
       let .getFollower(_, page, size, sortType):
       let params: [String: Any] = [
         "page": page,
         "size": size,
-        "sortType": sortType.toString()
+        "sortType": sortType.toString(),
       ]
       return .requestParameters(parameters: params, encoding: URLEncoding.queryString)
     case let .searchFollowingByNickname(size, nickname, lastID),
@@ -127,20 +132,20 @@ extension FollowRouter: TargetType, AccessTokenAuthorizable {
       return .requestPlain
     }
   }
-  
+
   var headers: [String: String]? {
     switch self {
     default:
       return ["Content-type": "application/json"]
     }
   }
-  
+
   var authorizationType: Moya.AuthorizationType? {
     return .bearer
   }
-  
+
   var validationType: ValidationType {
     return .successCodes
   }
-  
+
 }

--- a/Odya-iOS/Api/Routers/ImageRouter.swift
+++ b/Odya-iOS/Api/Routers/ImageRouter.swift
@@ -28,7 +28,7 @@ extension ImageRouter: TargetType, AccessTokenAuthorizable {
     case .getImages:
       return "/api/v1/images"
     case let .registerPOTD(imageId, _),
-         let .deletePOTD(imageId):
+      let .deletePOTD(imageId):
       return "/api/v1/images/\(imageId)/life-shot"
     }
   }
@@ -74,4 +74,3 @@ extension ImageRouter: TargetType, AccessTokenAuthorizable {
     return .successCodes
   }
 }
-

--- a/Odya-iOS/Api/Routers/ReportRouter.swift
+++ b/Odya-iOS/Api/Routers/ReportRouter.swift
@@ -21,7 +21,7 @@ extension ReportRouter: TargetType, AccessTokenAuthorizable {
   var baseURL: URL {
     return URL(string: ApiClient.BASE_URL)!
   }
-  
+
   var path: String {
     switch self {
     case .reportPlaceReview:
@@ -32,11 +32,11 @@ extension ReportRouter: TargetType, AccessTokenAuthorizable {
       return "/api/v1/reports/community"
     }
   }
-  
+
   var method: Moya.Method {
     return .post
   }
-  
+
   var task: Moya.Task {
     switch self {
     case .reportPlaceReview(let placeReviewId, let reportReason, let otherReason):
@@ -59,15 +59,15 @@ extension ReportRouter: TargetType, AccessTokenAuthorizable {
       return .requestParameters(parameters: params, encoding: JSONEncoding.prettyPrinted)
     }
   }
-  
-  var headers: [String : String]? {
+
+  var headers: [String: String]? {
     return ["Content-type": "application/json"]
   }
-  
+
   var authorizationType: Moya.AuthorizationType? {
     return .bearer
   }
-  
+
   var validationType: ValidationType {
     return .successCodes
   }

--- a/Odya-iOS/Api/Routers/ReviewRouter.swift
+++ b/Odya-iOS/Api/Routers/ReviewRouter.swift
@@ -5,111 +5,111 @@
 //  Created by Jade Yoo on 2023/07/22.
 //
 
-import SwiftUI
 import Alamofire
+import SwiftUI
 
 // 한줄리뷰 라우터
 // 한줄리뷰 CRUD
 
 enum ReviewRouter: URLRequestConvertible {
-    // MARK: - ID Token 대입
-    
-    var idToken: String {
-        return "Firebase Id Token"
-    }
-    
-    // MARK: - Cases
-    
-    case createReview(placeId: String, rating: Int, review: String)
-    case readPlaceIdReview(placeId: String, size: Int?, sortType: String?, lastId: Int?)
-    case readUserIdReview(userId: Int, size: Int?, sortType: String?, lastId: Int?)
-    case updateReview(id: Int, rating: Int?, review: String?)
-    case deleteReview(reviewId: Int)
-    
-    // MARK: - Properties
-    
-    var baseURL: String {
-        return "https://jayden-bin.kro.kr"
-    }
-    
-    var header: HTTPHeaders {
-        return [.authorization(bearerToken: idToken)]
-    }
-    
-    var endPoint: String {
-        switch self {
-        case let .readPlaceIdReview(placeId, _, _, _):
-            return "/api/v1/place-reviews/places/" + "\(placeId)"
-        case let .readUserIdReview(userId, _, _, _):
-            return "/api/v1/place-reviews/users/" + "\(userId)"
-        case let .deleteReview(reviewId):
-            return "/api/v1/place-reviews/" + "\(reviewId)"
-        default:
-            return "/api/v1/place-reviews"
-        }
-    }
-    
-    var method: HTTPMethod {
-        switch self {
-        case .createReview:
-            return .post
-        case .updateReview:
-            return .patch
-        case .deleteReview:
-            return .delete
-        case .readPlaceIdReview, .readUserIdReview:
-            return .get
-        }
-    }
-    
-    var parameter: Parameters {
-        switch self {
-        case let .createReview(placeId, rating, review):
-            var params = Parameters()
-            params["placeId"] = placeId
-            params["rating"] = rating
-            params["review"] = review
-            return params
-        case let .updateReview(id, rating, review):
-            var params = Parameters()
-            params["id"] = id
-            params["rating"] = rating
-            params["review"] = review
-            return params
-        case .deleteReview(_):
-            let params = Parameters()
-            return params
-        case let .readPlaceIdReview(_, size, sortType, lastId):
-            var params = Parameters()
-            params["size"] = size
-            params["sortType"] = sortType
-            params["lastId"] = lastId
-            return params
-        case let .readUserIdReview(_, size, sortType, lastId):
-            var params = Parameters()
-            params["size"] = size
-            params["sortType"] = sortType
-            params["lastId"] = lastId
-            return params
-        }
-    }
-    
-    // MARK: - URLRequestConvertible
-    func asURLRequest() throws -> URLRequest {
-        let url = URL(string: baseURL)!.appendingPathComponent(endPoint)
-        
-        var request = URLRequest(url: url)
+  // MARK: - ID Token 대입
 
-        switch self {
-        case .createReview, .updateReview, .deleteReview:
-            request.httpBody = try JSONEncoding.prettyPrinted.encode(request, with: parameter).httpBody
-        case .readPlaceIdReview, .readUserIdReview:
-            request = try URLEncoding.queryString.encode(request, with: parameter)
-        }
-        
-        request.method = method
-        request.headers = header
-        
-        return request
+  var idToken: String {
+    return "Firebase Id Token"
+  }
+
+  // MARK: - Cases
+
+  case createReview(placeId: String, rating: Int, review: String)
+  case readPlaceIdReview(placeId: String, size: Int?, sortType: String?, lastId: Int?)
+  case readUserIdReview(userId: Int, size: Int?, sortType: String?, lastId: Int?)
+  case updateReview(id: Int, rating: Int?, review: String?)
+  case deleteReview(reviewId: Int)
+
+  // MARK: - Properties
+
+  var baseURL: String {
+    return "https://jayden-bin.kro.kr"
+  }
+
+  var header: HTTPHeaders {
+    return [.authorization(bearerToken: idToken)]
+  }
+
+  var endPoint: String {
+    switch self {
+    case let .readPlaceIdReview(placeId, _, _, _):
+      return "/api/v1/place-reviews/places/" + "\(placeId)"
+    case let .readUserIdReview(userId, _, _, _):
+      return "/api/v1/place-reviews/users/" + "\(userId)"
+    case let .deleteReview(reviewId):
+      return "/api/v1/place-reviews/" + "\(reviewId)"
+    default:
+      return "/api/v1/place-reviews"
     }
+  }
+
+  var method: HTTPMethod {
+    switch self {
+    case .createReview:
+      return .post
+    case .updateReview:
+      return .patch
+    case .deleteReview:
+      return .delete
+    case .readPlaceIdReview, .readUserIdReview:
+      return .get
+    }
+  }
+
+  var parameter: Parameters {
+    switch self {
+    case let .createReview(placeId, rating, review):
+      var params = Parameters()
+      params["placeId"] = placeId
+      params["rating"] = rating
+      params["review"] = review
+      return params
+    case let .updateReview(id, rating, review):
+      var params = Parameters()
+      params["id"] = id
+      params["rating"] = rating
+      params["review"] = review
+      return params
+    case .deleteReview(_):
+      let params = Parameters()
+      return params
+    case let .readPlaceIdReview(_, size, sortType, lastId):
+      var params = Parameters()
+      params["size"] = size
+      params["sortType"] = sortType
+      params["lastId"] = lastId
+      return params
+    case let .readUserIdReview(_, size, sortType, lastId):
+      var params = Parameters()
+      params["size"] = size
+      params["sortType"] = sortType
+      params["lastId"] = lastId
+      return params
+    }
+  }
+
+  // MARK: - URLRequestConvertible
+  func asURLRequest() throws -> URLRequest {
+    let url = URL(string: baseURL)!.appendingPathComponent(endPoint)
+
+    var request = URLRequest(url: url)
+
+    switch self {
+    case .createReview, .updateReview, .deleteReview:
+      request.httpBody = try JSONEncoding.prettyPrinted.encode(request, with: parameter).httpBody
+    case .readPlaceIdReview, .readUserIdReview:
+      request = try URLEncoding.queryString.encode(request, with: parameter)
+    }
+
+    request.method = method
+    request.headers = header
+
+    return request
+  }
 }

--- a/Odya-iOS/Api/Routers/TermsRouter.swift
+++ b/Odya-iOS/Api/Routers/TermsRouter.swift
@@ -9,43 +9,42 @@ import Foundation
 import Moya
 
 enum TermsRouter {
-    case getTermsList
-    case getTermsContent(termsId: Int)
+  case getTermsList
+  case getTermsContent(termsId: Int)
 }
 
 extension TermsRouter: TargetType {
-    var baseURL: URL {
-        return URL(string: ApiClient.BASE_URL)!
+  var baseURL: URL {
+    return URL(string: ApiClient.BASE_URL)!
+  }
+
+  var path: String {
+    switch self {
+    case .getTermsList:
+      return "/api/v1/auth/terms"
+    case .getTermsContent(let termsId):
+      return "/api/v1/auth/terms/\(termsId)"
     }
-    
-    var path: String {
-        switch self {
-        case .getTermsList:
-            return "/api/v1/auth/terms"
-        case .getTermsContent(let termsId):
-            return "/api/v1/auth/terms/\(termsId)"
-        }
+  }
+
+  var method: Moya.Method {
+    switch self {
+    case .getTermsList, .getTermsContent:
+      return .get
     }
-    
-    var method: Moya.Method {
-        switch self {
-        case .getTermsList, .getTermsContent:
-            return .get
-        }
+  }
+
+  var task: Moya.Task {
+    switch self {
+    case .getTermsList:
+      return .requestPlain
+    case .getTermsContent:
+      return .requestPlain
     }
-    
-    var task: Moya.Task {
-        switch self {
-        case .getTermsList:
-            return .requestPlain
-        case .getTermsContent:
-            return .requestPlain
-        }
-    }
-    
-    var headers: [String : String]? {
-        return ["Content-type": "application/json" ]
-    }
-    
-    
+  }
+
+  var headers: [String: String]? {
+    return ["Content-type": "application/json"]
+  }
+
 }

--- a/Odya-iOS/Api/Routers/TopicRouter.swift
+++ b/Odya-iOS/Api/Routers/TopicRouter.swift
@@ -38,7 +38,7 @@ extension TopicRouter: TargetType, AccessTokenAuthorizable {
   var method: Moya.Method {
     switch self {
     case .createMyTopic:
-        return .post
+      return .post
     case .deleteMyTopic:
       return .delete
     default:
@@ -49,7 +49,7 @@ extension TopicRouter: TargetType, AccessTokenAuthorizable {
   var task: Moya.Task {
     switch self {
     case .createMyTopic(let idList):
-      let params: [String : [Int]] = ["topicIdList" : idList]
+      let params: [String: [Int]] = ["topicIdList": idList]
       return .requestParameters(parameters: params, encoding: JSONEncoding.default)
     default:
       return .requestPlain

--- a/Odya-iOS/Api/Routers/TravelJournalBookmarkRouter.swift
+++ b/Odya-iOS/Api/Routers/TravelJournalBookmarkRouter.swift
@@ -48,12 +48,8 @@ extension TravelJournalBookmarkRouter: TargetType, AccessTokenAuthorizable {
     switch self {
     case let .getBookmarkedJournals(size, lastId):
       var params: [String: Any] = [:]
-      if let size = size {
         params["size"] = size
-      }
-      if let lastId = lastId {
         params["lastId"] = lastId
-      }
       return .requestParameters(parameters: params, encoding: URLEncoding.queryString)
     default:
       return .requestPlain

--- a/Odya-iOS/Api/Routers/TravelJournalBookmarkRouter.swift
+++ b/Odya-iOS/Api/Routers/TravelJournalBookmarkRouter.swift
@@ -1,0 +1,79 @@
+//
+//  TravelJournalBookmarkRouter.swift
+//  Odya-iOS
+//
+//  Created by Heeoh Son on 2023/12/14.
+//
+
+import Foundation
+import Moya
+
+// MARK: Travel Journal Bookmark Enum
+enum TravelJournalBookmarkRouter {
+  // 여행일지 북마크 생성(즐겨찾기 추가)
+    case createBookmark(journalId: Int)
+  // 즐겨찾기된 여행일지 목록 조회
+    case getBookmarkedJournals(size: Int?, lastId: Int?)
+  // 여행일지 북마크 삭제(즐겨찾기 해제)
+    case deleteBookmark(journalId: Int)
+}
+
+extension TravelJournalBookmarkRouter: TargetType, AccessTokenAuthorizable {
+  var baseURL: URL {
+    return URL(string: ApiClient.BASE_URL)!
+  }
+  
+  var path: String {
+    switch self {
+    case let .createBookmark(journalId),
+      let .deleteBookmark(journalId):
+      return "/api/v1/travel-journal-bookmarks/\(journalId)"
+    case .getBookmarkedJournals:
+      return "/api/v1/travel-journal-bookmarks/me"
+    }
+  }
+  
+  var method: Moya.Method {
+    switch self {
+    case .createBookmark:
+      return .post
+    case .deleteBookmark:
+      return .delete
+    default:
+      return .get
+    }
+  }
+  
+  var task: Moya.Task {
+    switch self {
+    case let .getBookmarkedJournals(size, lastId):
+      var params: [String: Any] = [:]
+      if let size = size {
+        params["size"] = size
+      }
+      if let lastId = lastId {
+        params["lastId"] = lastId
+      }
+      return .requestParameters(parameters: params, encoding: URLEncoding.queryString)
+    default:
+      return .requestPlain
+    }
+  }
+  
+  var headers: [String: String]? {
+    switch self {
+    default:
+      return ["Content-type": "application/json"]
+    }
+  }
+  
+  var authorizationType: Moya.AuthorizationType? {
+    return .bearer
+  }
+  
+  var validationType: ValidationType {
+    return .successCodes
+  }
+  
+}
+

--- a/Odya-iOS/Api/Routers/TravelJournalBookmarkRouter.swift
+++ b/Odya-iOS/Api/Routers/TravelJournalBookmarkRouter.swift
@@ -11,18 +11,18 @@ import Moya
 // MARK: Travel Journal Bookmark Enum
 enum TravelJournalBookmarkRouter {
   // 여행일지 북마크 생성(즐겨찾기 추가)
-    case createBookmark(journalId: Int)
+  case createBookmark(journalId: Int)
   // 즐겨찾기된 여행일지 목록 조회
-    case getBookmarkedJournals(size: Int?, lastId: Int?)
+  case getBookmarkedJournals(size: Int?, lastId: Int?)
   // 여행일지 북마크 삭제(즐겨찾기 해제)
-    case deleteBookmark(journalId: Int)
+  case deleteBookmark(journalId: Int)
 }
 
 extension TravelJournalBookmarkRouter: TargetType, AccessTokenAuthorizable {
   var baseURL: URL {
     return URL(string: ApiClient.BASE_URL)!
   }
-  
+
   var path: String {
     switch self {
     case let .createBookmark(journalId),
@@ -32,7 +32,7 @@ extension TravelJournalBookmarkRouter: TargetType, AccessTokenAuthorizable {
       return "/api/v1/travel-journal-bookmarks/me"
     }
   }
-  
+
   var method: Moya.Method {
     switch self {
     case .createBookmark:
@@ -43,33 +43,32 @@ extension TravelJournalBookmarkRouter: TargetType, AccessTokenAuthorizable {
       return .get
     }
   }
-  
+
   var task: Moya.Task {
     switch self {
     case let .getBookmarkedJournals(size, lastId):
       var params: [String: Any] = [:]
-        params["size"] = size
-        params["lastId"] = lastId
+      params["size"] = size
+      params["lastId"] = lastId
       return .requestParameters(parameters: params, encoding: URLEncoding.queryString)
     default:
       return .requestPlain
     }
   }
-  
+
   var headers: [String: String]? {
     switch self {
     default:
       return ["Content-type": "application/json"]
     }
   }
-  
+
   var authorizationType: Moya.AuthorizationType? {
     return .bearer
   }
-  
+
   var validationType: ValidationType {
     return .successCodes
   }
-  
-}
 
+}

--- a/Odya-iOS/Api/Routers/TravelJournalRouter.swift
+++ b/Odya-iOS/Api/Routers/TravelJournalRouter.swift
@@ -5,301 +5,327 @@
 //  Created by Heeoh Son on 2023/10/15.
 //
 
-import SwiftUI
 import Moya
+import SwiftUI
 
 // Test
-func checkRequestSize(_ formData:  [MultipartFormData] ) -> Void {
+func checkRequestSize(_ formData: [MultipartFormData]) {
   var multipartDataSize: Int = 0
-  
+
   for multipartData in formData {
     if case .data(let data) = multipartData.provider {
       multipartDataSize += data.count
     }
   }
-  
+
   print("MultipartFormData 데이터 크기: \(multipartDataSize) bytes")
 }
 
 // MARK: Api Request Data
 struct TravelJournalContentRequest: Codable {
-    var content: String
-    var placeId: String?
-    var latitudes: [Double]
-    var longitudes: [Double]
-    var travelDate: [Int]
-    var contentImageNames: [String]
+  var content: String
+  var placeId: String?
+  var latitudes: [Double]
+  var longitudes: [Double]
+  var travelDate: [Int]
+  var contentImageNames: [String]
 }
 
 struct TravelJournalContentUpdateRequest: Codable {
-    var content: String
-    var placeId: String?
-    var latitudes: [Double]
-    var longitudes: [Double]
-    var travelDate: [Int]
-    var updateContentImageNames: [String]
-    var deleteContentImageIds: [Int]
-    var updateImageTotalCount: Int
+  var content: String
+  var placeId: String?
+  var latitudes: [Double]
+  var longitudes: [Double]
+  var travelDate: [Int]
+  var updateContentImageNames: [String]
+  var deleteContentImageIds: [Int]
+  var updateImageTotalCount: Int
 }
 
 struct TravelJournalRequest: Codable {
-    var title: String
-    var travelStartDate: [Int]
-    var travelEndDate: [Int]
-    var visibility: String
-    var travelCompanionIds: [Int]
-    var travelCompanionNames: [String]
-    var travelJournalContentRequests: [TravelJournalContentRequest]
-    var travelDurationDays: Int
-    var contentImageNameTotalCount: Int
+  var title: String
+  var travelStartDate: [Int]
+  var travelEndDate: [Int]
+  var visibility: String
+  var travelCompanionIds: [Int]
+  var travelCompanionNames: [String]
+  var travelJournalContentRequests: [TravelJournalContentRequest]
+  var travelDurationDays: Int
+  var contentImageNameTotalCount: Int
 }
 
 struct TravelJournalUpdateRequest: Codable {
-    var title: String
-    var travelStartDate: [Int]
-    var travelEndDate: [Int]
-    var visibility: String
-    var travelCompanionIds: [Int]
-    var travelCompanionNames: [String]
-    var travelDurationDays: Int
-    var updateTravelCompanionTotalCount: Int
+  var title: String
+  var travelStartDate: [Int]
+  var travelEndDate: [Int]
+  var visibility: String
+  var travelCompanionIds: [Int]
+  var travelCompanionNames: [String]
+  var travelDurationDays: Int
+  var updateTravelCompanionTotalCount: Int
 }
 
 // MARK: Travel Journal Enum
 enum TravelJournalRouter {
   // 여행일지 생성
-    case create(token: String,
-                title: String,
-                startDate: [Int],
-                endDate: [Int],
-                visibility: String,
-                travelMateIds: [Int],
-                travelMateNames: [String],
-                dailyJournals: [DailyTravelJournal],
-                travelDuration: Int,
-                imagesTotalCount: Int,
-                images: [(data: Data, name: String)])
+  case create(
+    token: String,
+    title: String,
+    startDate: [Int],
+    endDate: [Int],
+    visibility: String,
+    travelMateIds: [Int],
+    travelMateNames: [String],
+    dailyJournals: [DailyTravelJournal],
+    travelDuration: Int,
+    imagesTotalCount: Int,
+    images: [(data: Data, name: String)])
   // 여행일지 삭제
-    case delete(token: String, journalId: Int)
+  case delete(token: String, journalId: Int)
   // 여행일지 기본정보 수정
-    case edit(token: String, journalId: Int,
-              title: String,
-              startDate: [Int],
-              endDate: [Int],
-              visibility: String,
-              travelMateIds: [Int],
-              travelMateNames: [String],
-              travelDuration: Int,
-              newTravelMatesCount: Int)
+  case edit(
+    token: String, journalId: Int,
+    title: String,
+    startDate: [Int],
+    endDate: [Int],
+    visibility: String,
+    travelMateIds: [Int],
+    travelMateNames: [String],
+    travelDuration: Int,
+    newTravelMatesCount: Int)
   // 여행일지 데일리 일정 삭제
-    case deleteContent(token: String, journalId: Int, contentId: Int)
+  case deleteContent(token: String, journalId: Int, contentId: Int)
   // 여행일지 데일리 일정 수정
-    case editContent(token: String, journalId: Int, contentId: Int,
-                     content: String,
-                     placeId: String?,
-                     latitudes: [Double],
-                     longitudes: [Double],
-                     date: [Int],
-                     newImageNames: [String],
-                     deletedImageIds: [Int],
-                     newImageTotalCount: Int,
-                     images: [(data: Data, name: String)])
+  case editContent(
+    token: String, journalId: Int, contentId: Int,
+    content: String,
+    placeId: String?,
+    latitudes: [Double],
+    longitudes: [Double],
+    date: [Int],
+    newImageNames: [String],
+    deletedImageIds: [Int],
+    newImageTotalCount: Int,
+    images: [(data: Data, name: String)])
   // 함께 간 친구 삭제
   // 태그된 사용자가 태그를 지울때... 사용되는 것 같음.. 아마도
-    case deleteTravelMates(token: String, journalId: Int)
-  
+  case deleteTravelMates(token: String, journalId: Int)
+
   // 여행일지 아이디로 검색
   // 해당 여행일지의 디테일 정보를 모두 가져옴
-    case searchById(token: String, journalId: Int)
+  case searchById(token: String, journalId: Int)
   // 여행일지 목록 조회
-    case getJournals(token: String, size: Int?, lastId: Int?)
+  case getJournals(token: String, size: Int?, lastId: Int?)
   // 내 여행일지 목록 조회
-    case getMyJournals(token: String, size: Int?, lastId: Int?)
+  case getMyJournals(token: String, size: Int?, lastId: Int?)
   // 친구 여행일지 목록 조회
-    case getFriendsJournals(token: String, size: Int?, lastId: Int?)
+  case getFriendsJournals(token: String, size: Int?, lastId: Int?)
   // 추천 여행일지 목록 조회
-    case getRecommendedJournals(token: String, size: Int?, lastId: Int?)
+  case getRecommendedJournals(token: String, size: Int?, lastId: Int?)
   // 태그된 여행일지 목록 조회
-    case getTaggedJournals(token: String, size: Int?, lastId: Int?)
-    
+  case getTaggedJournals(token: String, size: Int?, lastId: Int?)
+
   // 여행일지 북마크 생성(즐겨찾기 추가)
-    case createBookmark(token: String, journalId: Int)
+  case createBookmark(token: String, journalId: Int)
   // 즐겨찾기된 여행일지 목록 조회
-    case getBookmarkedJournals(token: String, size: Int?, lastId: Int?)
+  case getBookmarkedJournals(token: String, size: Int?, lastId: Int?)
   // 여행일지 북마크 삭제(즐겨찾기 해제)
-    case deleteBookmark(token: String, journalId: Int)
+  case deleteBookmark(token: String, journalId: Int)
 
 }
 
 extension TravelJournalRouter: TargetType, AccessTokenAuthorizable {
-    
-    var baseURL: URL {
-        return URL(string: ApiClient.BASE_URL)!
-    }
-    
-    var path: String {
-        switch self {
-        case .create, .getJournals:
-            return "/api/v1/travel-journals"
-        case let .searchById(_, journalId),
-            let .edit(_, journalId, _, _, _, _, _, _, _, _),
-            let .delete(_, journalId):
-            return "/api/v1/travel-journals/\(journalId)"
-        case let .editContent(_, journalId, contentId, _, _, _, _, _, _, _, _, _),
-            let .deleteContent(_, journalId, contentId):
-            return "/api/v1/travel-journals/\(journalId)/\(contentId)"
-        case let .deleteTravelMates(_, journalId):
-            return "/api/v1/travel-journals/\(journalId)/travelCompanion"
-        case .getMyJournals:
-            return "/api/v1/travel-journals/me"
-        case .getFriendsJournals:
-            return "/api/v1/travel-journals/friends"
-        case .getRecommendedJournals:
-            return "/api/v1/travel-journals/recommends"
-        case .getTaggedJournals:
-            return "/api/v1/travel-journals/tagged"
-        case let .createBookmark(_, journalId),
-             let .deleteBookmark(_, journalId):
-            return "/api/v1/travel-journal-bookmarks/\(journalId)"
-        case .getBookmarkedJournals:
-            return "/api/v1/travel-journal-bookmarks/me"
-        }
-    }
-    
-    var method: Moya.Method {
-        switch self {
-        case .create, .createBookmark:
-            return .post
-        case .edit, .editContent:
-            return .put
-        case .delete, .deleteContent, .deleteTravelMates, .deleteBookmark:
-            return .delete
-        default:
-            return .get
-        }
-    }
-    
-    var task: Moya.Task {
-        switch self {
-            // TODO: Create, Edit, EditContent
-        case let .create(_, title, startDate, endDate, visibility, travelMateIds, travelMateNames, dailyJournals, travelDuration, imagesTotalCount, images):
-            
-            var travelJournalContents: [TravelJournalContentRequest] = []
-            for dailyJournal in dailyJournals {
-                travelJournalContents.append(
-                    TravelJournalContentRequest(content: dailyJournal.content,
-                                                latitudes: dailyJournal.latitudes,
-                                                longitudes: dailyJournal.longitudes,
-                                                travelDate: dailyJournal.date?.toIntArray() ?? [],
-                                                contentImageNames: dailyJournal.selectedImages.map{ $0.imageName + ".webp" }))
-            }
 
-            
-            let travelJournal = TravelJournalRequest(title: title,
-                                                     travelStartDate: startDate,
-                                                     travelEndDate: endDate,
-                                                     visibility: visibility,
-                                                     travelCompanionIds: travelMateIds,
-                                                     travelCompanionNames: travelMateNames,
-                                                     travelJournalContentRequests: travelJournalContents,
-                                                     travelDurationDays: travelDuration,
-                                                     contentImageNameTotalCount: imagesTotalCount)
-            var formData: [MultipartFormData] = []
-            do {
-                let travelJournalJSONData = try JSONEncoder().encode(travelJournal)
-                formData.append(MultipartFormData(provider: .data(travelJournalJSONData), name: "travel-journal", fileName: "travel-journal", mimeType: "application/json"))
-                
-                for image in images {
-                    formData.append(MultipartFormData(provider: .data(image.data), name: "travel-journal-content-image", fileName: "\(image.name)", mimeType: "image/webp"))
-                }
-              
-            } catch {
-                print("JSON 인코딩 에러: \(error)")
-            }
-          // checkRequestSize(formData)
-            return .uploadMultipart(formData)
-        case let .edit(_, _, title, startDate, endDate, visibility, travelMateIds, travelMateNames, travelDuration, newTravelMatesCount):
-            let newTravelJournal = TravelJournalUpdateRequest(title: title,
-                                                     travelStartDate: startDate,
-                                                     travelEndDate: endDate,
-                                                     visibility: visibility,
-                                                     travelCompanionIds: travelMateIds,
-                                                     travelCompanionNames: travelMateNames,
-                                                     travelDurationDays: travelDuration,
-                                                     updateTravelCompanionTotalCount: newTravelMatesCount)
-            var formData: [MultipartFormData] = []
-            do {
-                let travelJournalJSONData = try JSONEncoder().encode(newTravelJournal)
-                formData.append(MultipartFormData(provider: .data(travelJournalJSONData), name: "travel-journal-update", fileName: "travel-journal", mimeType: "application/json"))
-            } catch {
-                print("JSON 인코딩 에러: \(error)")
-            }
-            return .uploadMultipart(formData)
-        case let .editContent(_, _, _, content, placeId, latitudes, longitudes, date, newImageNames, deletedImageIds, newImageTotalCount, images):
-            let newTravelJournalContent =
-            TravelJournalContentUpdateRequest(content: content,
-                                              placeId: placeId,
-                                              latitudes: latitudes,
-                                              longitudes: longitudes,
-                                              travelDate: date,
-                                              updateContentImageNames: newImageNames,
-                                              deleteContentImageIds: deletedImageIds,
-                                              updateImageTotalCount: newImageTotalCount)
-            var formData: [MultipartFormData] = []
-            do {
-                let travelJournalJSONData = try JSONEncoder().encode(newTravelJournalContent)
-                formData.append(MultipartFormData(provider: .data(travelJournalJSONData), name: "travel-journal-content-update", fileName: "travel-journal", mimeType: "application/json"))
-                
-                for image in images {
-                    formData.append(MultipartFormData(provider: .data(image.data), name: "travel-journal-content-image-update", fileName: "\(image.name)", mimeType: "image/webp"))
-                }
-            } catch {
-                print("JSON 인코딩 에러: \(error)")
-            }
-            return .uploadMultipart(formData)
-        case let .getJournals(_, size, lastId),
-            let .getMyJournals(_, size, lastId),
-            let .getFriendsJournals(_, size, lastId),
-            let .getRecommendedJournals(_, size, lastId),
-            let .getTaggedJournals(_, size, lastId),
-            let .getBookmarkedJournals(_, size, lastId):
-            var params: [String: Any] = [:]
-            if let size = size {
-                params["size"] = size
-            }
-            if let lastId = lastId {
-                params["lastId"] = lastId
-            }
-            return .requestParameters(parameters: params, encoding: URLEncoding.queryString)
-        default:
-            return .requestPlain
+  var baseURL: URL {
+    return URL(string: ApiClient.BASE_URL)!
+  }
+
+  var path: String {
+    switch self {
+    case .create, .getJournals:
+      return "/api/v1/travel-journals"
+    case let .searchById(_, journalId),
+      let .edit(_, journalId, _, _, _, _, _, _, _, _),
+      let .delete(_, journalId):
+      return "/api/v1/travel-journals/\(journalId)"
+    case let .editContent(_, journalId, contentId, _, _, _, _, _, _, _, _, _),
+      let .deleteContent(_, journalId, contentId):
+      return "/api/v1/travel-journals/\(journalId)/\(contentId)"
+    case let .deleteTravelMates(_, journalId):
+      return "/api/v1/travel-journals/\(journalId)/travelCompanion"
+    case .getMyJournals:
+      return "/api/v1/travel-journals/me"
+    case .getFriendsJournals:
+      return "/api/v1/travel-journals/friends"
+    case .getRecommendedJournals:
+      return "/api/v1/travel-journals/recommends"
+    case .getTaggedJournals:
+      return "/api/v1/travel-journals/tagged"
+    case let .createBookmark(_, journalId),
+      let .deleteBookmark(_, journalId):
+      return "/api/v1/travel-journal-bookmarks/\(journalId)"
+    case .getBookmarkedJournals:
+      return "/api/v1/travel-journal-bookmarks/me"
+    }
+  }
+
+  var method: Moya.Method {
+    switch self {
+    case .create, .createBookmark:
+      return .post
+    case .edit, .editContent:
+      return .put
+    case .delete, .deleteContent, .deleteTravelMates, .deleteBookmark:
+      return .delete
+    default:
+      return .get
+    }
+  }
+
+  var task: Moya.Task {
+    switch self {
+    // TODO: Create, Edit, EditContent
+    case let .create(
+      _, title, startDate, endDate, visibility, travelMateIds, travelMateNames, dailyJournals,
+      travelDuration, imagesTotalCount, images):
+
+      var travelJournalContents: [TravelJournalContentRequest] = []
+      for dailyJournal in dailyJournals {
+        travelJournalContents.append(
+          TravelJournalContentRequest(
+            content: dailyJournal.content,
+            latitudes: dailyJournal.latitudes,
+            longitudes: dailyJournal.longitudes,
+            travelDate: dailyJournal.date?.toIntArray() ?? [],
+            contentImageNames: dailyJournal.selectedImages.map { $0.imageName + ".webp" }))
+      }
+
+      let travelJournal = TravelJournalRequest(
+        title: title,
+        travelStartDate: startDate,
+        travelEndDate: endDate,
+        visibility: visibility,
+        travelCompanionIds: travelMateIds,
+        travelCompanionNames: travelMateNames,
+        travelJournalContentRequests: travelJournalContents,
+        travelDurationDays: travelDuration,
+        contentImageNameTotalCount: imagesTotalCount)
+      var formData: [MultipartFormData] = []
+      do {
+        let travelJournalJSONData = try JSONEncoder().encode(travelJournal)
+        formData.append(
+          MultipartFormData(
+            provider: .data(travelJournalJSONData), name: "travel-journal",
+            fileName: "travel-journal", mimeType: "application/json"))
+
+        for image in images {
+          formData.append(
+            MultipartFormData(
+              provider: .data(image.data), name: "travel-journal-content-image",
+              fileName: "\(image.name)", mimeType: "image/webp"))
         }
-    }
-    
-    var headers: [String : String]? {
-        switch self {
-        case let .create(token, _, _, _, _, _, _, _, _, _, _),
-            let .searchById(token, _),
-            let .getJournals(token, _, _),
-            let .getMyJournals(token, _, _),
-            let .getFriendsJournals(token, _, _),
-            let .getRecommendedJournals(token, _, _),
-            let .getTaggedJournals(token, _, _),
-            let .edit(token, _, _, _, _, _, _, _, _, _),
-            let .editContent(token, _, _, _, _, _, _, _, _, _, _, _),
-            let .delete(token, _),
-            let .deleteContent(token, _, _),
-            let .deleteTravelMates(token, _),
-            let .createBookmark(token, _),
-            let .getBookmarkedJournals(token, _, _),
-            let .deleteBookmark(token, _):
-            return ["Authorization" : "Bearer \(token)"]
+
+      } catch {
+        print("JSON 인코딩 에러: \(error)")
+      }
+      // checkRequestSize(formData)
+      return .uploadMultipart(formData)
+    case let .edit(
+      _, _, title, startDate, endDate, visibility, travelMateIds, travelMateNames, travelDuration,
+      newTravelMatesCount):
+      let newTravelJournal = TravelJournalUpdateRequest(
+        title: title,
+        travelStartDate: startDate,
+        travelEndDate: endDate,
+        visibility: visibility,
+        travelCompanionIds: travelMateIds,
+        travelCompanionNames: travelMateNames,
+        travelDurationDays: travelDuration,
+        updateTravelCompanionTotalCount: newTravelMatesCount)
+      var formData: [MultipartFormData] = []
+      do {
+        let travelJournalJSONData = try JSONEncoder().encode(newTravelJournal)
+        formData.append(
+          MultipartFormData(
+            provider: .data(travelJournalJSONData), name: "travel-journal-update",
+            fileName: "travel-journal", mimeType: "application/json"))
+      } catch {
+        print("JSON 인코딩 에러: \(error)")
+      }
+      return .uploadMultipart(formData)
+    case let .editContent(
+      _, _, _, content, placeId, latitudes, longitudes, date, newImageNames, deletedImageIds,
+      newImageTotalCount, images):
+      let newTravelJournalContent =
+        TravelJournalContentUpdateRequest(
+          content: content,
+          placeId: placeId,
+          latitudes: latitudes,
+          longitudes: longitudes,
+          travelDate: date,
+          updateContentImageNames: newImageNames,
+          deleteContentImageIds: deletedImageIds,
+          updateImageTotalCount: newImageTotalCount)
+      var formData: [MultipartFormData] = []
+      do {
+        let travelJournalJSONData = try JSONEncoder().encode(newTravelJournalContent)
+        formData.append(
+          MultipartFormData(
+            provider: .data(travelJournalJSONData), name: "travel-journal-content-update",
+            fileName: "travel-journal", mimeType: "application/json"))
+
+        for image in images {
+          formData.append(
+            MultipartFormData(
+              provider: .data(image.data), name: "travel-journal-content-image-update",
+              fileName: "\(image.name)", mimeType: "image/webp"))
         }
+      } catch {
+        print("JSON 인코딩 에러: \(error)")
+      }
+      return .uploadMultipart(formData)
+    case let .getJournals(_, size, lastId),
+      let .getMyJournals(_, size, lastId),
+      let .getFriendsJournals(_, size, lastId),
+      let .getRecommendedJournals(_, size, lastId),
+      let .getTaggedJournals(_, size, lastId),
+      let .getBookmarkedJournals(_, size, lastId):
+      var params: [String: Any] = [:]
+      if let size = size {
+        params["size"] = size
+      }
+      if let lastId = lastId {
+        params["lastId"] = lastId
+      }
+      return .requestParameters(parameters: params, encoding: URLEncoding.queryString)
+    default:
+      return .requestPlain
     }
-    
-    var authorizationType: Moya.AuthorizationType? {
-        return .bearer
+  }
+
+  var headers: [String: String]? {
+    switch self {
+    case let .create(token, _, _, _, _, _, _, _, _, _, _),
+      let .searchById(token, _),
+      let .getJournals(token, _, _),
+      let .getMyJournals(token, _, _),
+      let .getFriendsJournals(token, _, _),
+      let .getRecommendedJournals(token, _, _),
+      let .getTaggedJournals(token, _, _),
+      let .edit(token, _, _, _, _, _, _, _, _, _),
+      let .editContent(token, _, _, _, _, _, _, _, _, _, _, _),
+      let .delete(token, _),
+      let .deleteContent(token, _, _),
+      let .deleteTravelMates(token, _),
+      let .createBookmark(token, _),
+      let .getBookmarkedJournals(token, _, _),
+      let .deleteBookmark(token, _):
+      return ["Authorization": "Bearer \(token)"]
     }
-    
-    
+  }
+
+  var authorizationType: Moya.AuthorizationType? {
+    return .bearer
+  }
+
 }

--- a/Odya-iOS/Api/Routers/TravelJournalTagRouter.swift
+++ b/Odya-iOS/Api/Routers/TravelJournalTagRouter.swift
@@ -1,0 +1,77 @@
+//
+//  TravelJournalTagRouter.swift
+//  Odya-iOS
+//
+//  Created by Heeoh Son on 2023/12/14.
+//
+
+import Foundation
+import Moya
+
+enum TravelJournalTagRouter {
+  // 7. 태그된 여행일지 목록 조회
+  case getTaggedJournals(size: Int?, lastId: Int?)
+  // 12. 함께 간 친구 삭제
+  // 태그된 사용자가 태그를 지울때... 사용
+  case deleteTravelMates(journalId: Int)
+}
+
+
+extension TravelJournalTagRouter: TargetType, AccessTokenAuthorizable {
+    
+    var baseURL: URL {
+        return URL(string: ApiClient.BASE_URL)!
+    }
+    
+    var path: String {
+        switch self {
+        case .getTaggedJournals:
+            return "/api/v1/travel-journals/tagged"
+        case let .deleteTravelMates(journalId):
+            return "/api/v1/travel-journals/\(journalId)/travelCompanion"
+        
+        }
+    }
+    
+    var method: Moya.Method {
+        switch self {
+        case .deleteTravelMates:
+            return .delete
+        default:
+            return .get
+        }
+    }
+    
+    var task: Moya.Task {
+        switch self {
+  
+        case let .getTaggedJournals(size, lastId):
+            var params: [String: Any] = [:]
+            if let size = size {
+                params["size"] = size
+            }
+            if let lastId = lastId {
+                params["lastId"] = lastId
+            }
+            return .requestParameters(parameters: params, encoding: URLEncoding.queryString)
+        default:
+            return .requestPlain
+        }
+    }
+    
+  var headers: [String: String]? {
+    switch self {
+    default:
+      return ["Content-type": "application/json"]
+    }
+  }
+  
+  var authorizationType: Moya.AuthorizationType? {
+    return .bearer
+  }
+  
+  var validationType: ValidationType {
+    return .successCodes
+  }
+    
+}

--- a/Odya-iOS/Api/Routers/TravelJournalTagRouter.swift
+++ b/Odya-iOS/Api/Routers/TravelJournalTagRouter.swift
@@ -16,35 +16,34 @@ enum TravelJournalTagRouter {
   case deleteTravelMates(journalId: Int)
 }
 
-
 extension TravelJournalTagRouter: TargetType, AccessTokenAuthorizable {
-    
-    var baseURL: URL {
-        return URL(string: ApiClient.BASE_URL)!
+
+  var baseURL: URL {
+    return URL(string: ApiClient.BASE_URL)!
+  }
+
+  var path: String {
+    switch self {
+    case .getTaggedJournals:
+      return "/api/v1/travel-journals/tagged"
+    case let .deleteTravelMates(journalId):
+      return "/api/v1/travel-journals/\(journalId)/travelCompanion"
+
     }
-    
-    var path: String {
-        switch self {
-        case .getTaggedJournals:
-            return "/api/v1/travel-journals/tagged"
-        case let .deleteTravelMates(journalId):
-            return "/api/v1/travel-journals/\(journalId)/travelCompanion"
-        
-        }
+  }
+
+  var method: Moya.Method {
+    switch self {
+    case .deleteTravelMates:
+      return .delete
+    default:
+      return .get
     }
-    
-    var method: Moya.Method {
-        switch self {
-        case .deleteTravelMates:
-            return .delete
-        default:
-            return .get
-        }
-    }
-    
+  }
+
   var task: Moya.Task {
     switch self {
-      
+
     case let .getTaggedJournals(size, lastId):
       var params: [String: Any] = [:]
       params["size"] = size
@@ -54,20 +53,20 @@ extension TravelJournalTagRouter: TargetType, AccessTokenAuthorizable {
       return .requestPlain
     }
   }
-    
+
   var headers: [String: String]? {
     switch self {
     default:
       return ["Content-type": "application/json"]
     }
   }
-  
+
   var authorizationType: Moya.AuthorizationType? {
     return .bearer
   }
-  
+
   var validationType: ValidationType {
     return .successCodes
   }
-    
+
 }

--- a/Odya-iOS/Api/Routers/TravelJournalTagRouter.swift
+++ b/Odya-iOS/Api/Routers/TravelJournalTagRouter.swift
@@ -42,22 +42,18 @@ extension TravelJournalTagRouter: TargetType, AccessTokenAuthorizable {
         }
     }
     
-    var task: Moya.Task {
-        switch self {
-  
-        case let .getTaggedJournals(size, lastId):
-            var params: [String: Any] = [:]
-            if let size = size {
-                params["size"] = size
-            }
-            if let lastId = lastId {
-                params["lastId"] = lastId
-            }
-            return .requestParameters(parameters: params, encoding: URLEncoding.queryString)
-        default:
-            return .requestPlain
-        }
+  var task: Moya.Task {
+    switch self {
+      
+    case let .getTaggedJournals(size, lastId):
+      var params: [String: Any] = [:]
+      params["size"] = size
+      params["lastId"] = lastId
+      return .requestParameters(parameters: params, encoding: URLEncoding.queryString)
+    default:
+      return .requestPlain
     }
+  }
     
   var headers: [String: String]? {
     switch self {

--- a/Odya-iOS/Api/Routers/UserRouter.swift
+++ b/Odya-iOS/Api/Routers/UserRouter.swift
@@ -10,7 +10,7 @@ import Moya
 
 enum UserRouter {
   // 1. 사용자 정보 조회
-    case getUserInfo
+  case getUserInfo
   // 2. 이메일 변경
   case updateUserEmailAddress(newEmailAddr: String)
   // 3. 전화번호 변경
@@ -33,7 +33,7 @@ extension UserRouter: TargetType, AccessTokenAuthorizable {
   var baseURL: URL {
     return URL(string: ApiClient.BASE_URL)!
   }
-  
+
   var path: String {
     switch self {
     case .updateUserEmailAddress:
@@ -56,13 +56,13 @@ extension UserRouter: TargetType, AccessTokenAuthorizable {
       return "/api/v1/users/\(userId)/life-shots"
     }
   }
-  
+
   var method: Moya.Method {
     switch self {
     case .updateUserEmailAddress,
-        .updateUserPhoneNumber,
-        .updateUserNickname,
-        .updateUserProfileImage:
+      .updateUserPhoneNumber,
+      .updateUserNickname,
+      .updateUserProfileImage:
       return .patch
     case .deleteUser:
       return .delete
@@ -70,18 +70,21 @@ extension UserRouter: TargetType, AccessTokenAuthorizable {
       return .get
     }
   }
-  
+
   var task: Moya.Task {
     switch self {
     case .updateUserNickname(let newNickname):
-      let params: [String : Any] = ["nickname" : newNickname]
+      let params: [String: Any] = ["nickname": newNickname]
       return .requestParameters(parameters: params, encoding: JSONEncoding.prettyPrinted)
     case .updateUserProfileImage(let profileImg):
       guard let profileImg = profileImg else {
         return .requestPlain
       }
       var formData: [MultipartFormData] = []
-      formData.append(MultipartFormData(provider: .data(profileImg.data), name: "profile", fileName: "\(profileImg.name)", mimeType: "image/webp"))
+      formData.append(
+        MultipartFormData(
+          provider: .data(profileImg.data), name: "profile", fileName: "\(profileImg.name)",
+          mimeType: "image/webp"))
       return .uploadMultipart(formData)
     case .searchUser(let size, let lastId, let nickname):
       var params: [String: Any] = [:]
@@ -98,18 +101,18 @@ extension UserRouter: TargetType, AccessTokenAuthorizable {
       return .requestPlain
     }
   }
-  
+
   var headers: [String: String]? {
     switch self {
     default:
       return ["Content-type": "application/json"]
     }
   }
-  
+
   var authorizationType: Moya.AuthorizationType? {
     return .bearer
   }
-  
+
   var validationType: ValidationType {
     return .successCodes
   }

--- a/Odya-iOS/Components/Buttons/WriteButton.swift
+++ b/Odya-iOS/Components/Buttons/WriteButton.swift
@@ -7,20 +7,20 @@
 
 import SwiftUI
 
-//extension View {
-//    func WriteButton(action: @escaping () -> Void) -> some View {
-//        Button(action: action) {
-//            Circle()
-//                .fill(Color.odya.brand.primary)
-//                .frame(width: 56, height: 56)
-//                .floatingButtonShadow()
-//                .overlay (
-//                    Image("pen-m")
-//                        .colorMultiply(.odya.label.r_normal)
-//                )
-//        }
-//    }
-//}
+extension View {
+    func WriteButtonWithAction(action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Circle()
+                .fill(Color.odya.brand.primary)
+                .frame(width: 56, height: 56)
+                .floatingButtonShadow()
+                .overlay (
+                    Image("pen-m")
+                        .colorMultiply(.odya.label.r_normal)
+                )
+        }
+    }
+}
 
 struct WriteButton: View {
     var body: some View {

--- a/Odya-iOS/Core/Image/ImageGridView.swift
+++ b/Odya-iOS/Core/Image/ImageGridView.swift
@@ -9,38 +9,36 @@ import Foundation
 import SwiftUI
 
 struct ImageGridView: View {
-    var columns: [GridItem]
-    var images: [String]
-    var imageSize: CGFloat
-    var spacing: CGFloat
-    
-    init(images: [String], totalWidth: CGFloat, spacing: CGFloat = 0, count: Int = 3) {
-        self.images = images
-        self.spacing = spacing
-        let imageSize = (totalWidth - ((CGFloat(count) - 1) * spacing)) / CGFloat(count)
-        self.imageSize = imageSize
-        self.columns = Array(repeating: .init(.fixed(imageSize), spacing: spacing), count: count)
-    }
-
-    var body: some View {
-        VStack {
-            LazyVGrid(columns: columns, spacing: spacing) {
-                ForEach(images, id: \.self) { imageUrl in
-                    AsyncImage(url: URL(string: imageUrl)) { image in
-                        image
-                            .resizable()
-                            .aspectRatio(contentMode: .fill)
-                            .frame(width: imageSize, height: imageSize)
-                            .clipped()
-                    } placeholder: {
-                        ProgressView()
-                            .frame(width: imageSize, height: imageSize * 4/3)
-                    }
-                        
-                        
-                }
-            }
+  var columns: [GridItem]
+  var images: [String]
+  var imageSize: CGFloat
+  var spacing: CGFloat
+  
+  init(images: [String], totalWidth: CGFloat, spacing: CGFloat = 0, count: Int = 3) {
+    self.images = images
+    self.spacing = spacing
+    let imageSize = (totalWidth - ((CGFloat(count) - 1) * spacing)) / CGFloat(count)
+    self.imageSize = imageSize
+    self.columns = Array(repeating: .init(.fixed(imageSize), spacing: spacing), count: count)
+  }
+  
+  var body: some View {
+    VStack {
+      LazyVGrid(columns: columns, spacing: spacing) {
+        ForEach(images, id: \.self) { imageUrl in
+          AsyncImage(url: URL(string: imageUrl)) { image in
+            image
+              .resizable()
+              .aspectRatio(contentMode: .fill)
+              .frame(width: imageSize, height: imageSize)
+              .clipped()
+          } placeholder: {
+            ProgressView()
+              .frame(width: imageSize, height: imageSize)
+          }
         }
-        
+      }
     }
+    
+  }
 }

--- a/Odya-iOS/Core/TravelJournal/MyJournals/View/BookmarkedJournalListView.swift
+++ b/Odya-iOS/Core/TravelJournal/MyJournals/View/BookmarkedJournalListView.swift
@@ -9,11 +9,12 @@ import SwiftUI
 
 struct BookmarkedJournalListView: View {
   @EnvironmentObject var VM: BookmarkedJournalListViewModel
-  
+
   var body: some View {
     ZStack(alignment: .center) {
       if VM.isBookmarkedJournalsLoading
-          && VM.bookmarkedJournals.isEmpty {
+        && VM.bookmarkedJournals.isEmpty
+      {
         ProgressView()
           .frame(height: 224)
           .frame(maxWidth: .infinity)
@@ -26,28 +27,32 @@ struct BookmarkedJournalListView: View {
               linkToJournalDetail(journal: journal)
                 .onAppear {
                   if let last = VM.lastIdOfBookmarkedJournals,
-                     last == journal.bookmarkId {
+                    last == journal.bookmarkId
+                  {
                     VM.fetchMoreBookmarkedJournalsSubject.send()
                   }
                 }
-            } // ForEach
-          } // LazyHStack
-        } // ScrollView
+            }  // ForEach
+          }  // LazyHStack
+        }  // ScrollView
       }
-    } // ZStack
+    }  // ZStack
   }
-  
+
   private func linkToJournalDetail(journal: BookmarkedJournalData) -> some View {
     NavigationLink(
-      destination: TravelJournalDetailView(journalId: journal.journalId, nickname: journal.writer.nickname)
-        .navigationBarHidden(true)
+      destination: TravelJournalDetailView(
+        journalId: journal.journalId, nickname: journal.writer.nickname
+      )
+      .navigationBarHidden(true)
     ) {
       TravelJournalSmallCardView(
-        title: journal.title, date: journal.travelStartDate, imageUrl: journal.mainImageUrl, writer: journal.writer)
+        title: journal.title, date: journal.travelStartDate, imageUrl: journal.mainImageUrl,
+        writer: journal.writer)
     }.overlay {
       FavoriteJournalCardOverlayMenuView(journalId: journal.journalId)
         .environmentObject(VM)
     }
   }
-  
+
 }

--- a/Odya-iOS/Core/TravelJournal/MyJournals/View/BookmarkedJournalListView.swift
+++ b/Odya-iOS/Core/TravelJournal/MyJournals/View/BookmarkedJournalListView.swift
@@ -9,22 +9,13 @@ import SwiftUI
 
 struct BookmarkedJournalListView: View {
   @EnvironmentObject var VM: BookmarkedJournalListViewModel
-  @Binding var isShowingInMyJournalsView: Bool
   
-  var isReady: Bool {
-    VM.isBookmarkedJournalsLoading || !VM.bookmarkedJournals.isEmpty
-  }
-  
-  init(_ isShowing: Binding<Bool>) {
-    self._isShowingInMyJournalsView = isShowing
-    
-  }
-
   var body: some View {
     ZStack(alignment: .center) {
-      if VM.isBookmarkedJournalsLoading {
+      if VM.isBookmarkedJournalsLoading
+          && VM.bookmarkedJournals.isEmpty {
         ProgressView()
-          .frame(height: 250)
+          .frame(height: 224)
           .frame(maxWidth: .infinity)
       }
 
@@ -44,9 +35,6 @@ struct BookmarkedJournalListView: View {
         } // ScrollView
       }
     } // ZStack
-    .onChange(of: isReady) { newValue in
-      isShowingInMyJournalsView = newValue
-    }
   }
   
   private func linkToJournalDetail(journal: BookmarkedJournalData) -> some View {

--- a/Odya-iOS/Core/TravelJournal/MyJournals/View/BookmarkedJournalListView.swift
+++ b/Odya-iOS/Core/TravelJournal/MyJournals/View/BookmarkedJournalListView.swift
@@ -1,0 +1,65 @@
+//
+//  BookmarkedJournalListView.swift
+//  Odya-iOS
+//
+//  Created by Heeoh Son on 2023/12/14.
+//
+
+import SwiftUI
+
+struct BookmarkedJournalListView: View {
+  @EnvironmentObject var VM: BookmarkedJournalListViewModel
+  @Binding var isShowingInMyJournalsView: Bool
+  
+  var isReady: Bool {
+    VM.isBookmarkedJournalsLoading || !VM.bookmarkedJournals.isEmpty
+  }
+  
+  init(_ isShowing: Binding<Bool>) {
+    self._isShowingInMyJournalsView = isShowing
+    
+  }
+
+  var body: some View {
+    ZStack(alignment: .center) {
+      if VM.isBookmarkedJournalsLoading {
+        ProgressView()
+          .frame(height: 250)
+          .frame(maxWidth: .infinity)
+      }
+
+      else {
+        ScrollView(.horizontal, showsIndicators: false) {
+          LazyHStack(spacing: 10) {
+            ForEach(VM.bookmarkedJournals, id: \.id) { journal in
+              linkToJournalDetail(journal: journal)
+                .onAppear {
+                  if let last = VM.lastIdOfBookmarkedJournals,
+                     last == journal.bookmarkId {
+                    VM.fetchMoreBookmarkedJournalsSubject.send()
+                  }
+                }
+            } // ForEach
+          } // LazyHStack
+        } // ScrollView
+      }
+    } // ZStack
+    .onChange(of: isReady) { newValue in
+      isShowingInMyJournalsView = newValue
+    }
+  }
+  
+  private func linkToJournalDetail(journal: BookmarkedJournalData) -> some View {
+    NavigationLink(
+      destination: TravelJournalDetailView(journalId: journal.journalId, nickname: journal.writer.nickname)
+        .navigationBarHidden(true)
+    ) {
+      TravelJournalSmallCardView(
+        title: journal.title, date: journal.travelStartDate, imageUrl: journal.mainImageUrl, writer: journal.writer)
+    }.overlay {
+      FavoriteJournalCardOverlayMenuView(journalId: journal.journalId)
+        .environmentObject(VM)
+    }
+  }
+  
+}

--- a/Odya-iOS/Core/TravelJournal/MyJournals/View/MyJournalCardView.swift
+++ b/Odya-iOS/Core/TravelJournal/MyJournals/View/MyJournalCardView.swift
@@ -98,7 +98,7 @@ struct RandomJounalCardView: View {
 
 /// 내 추억 뷰에서 내 여행일지를 보여주기 위한 기본 크기의 카드 뷰
 struct TravelJournalCardView: View {
-  @EnvironmentObject var myJournalsVM: MyJournalsViewModel
+  @EnvironmentObject var bookmarkJournalsVM: BookmarkedJournalListViewModel
   @StateObject var bookmarkManager = JournalBookmarkManager()
   
   let cardHeight: CGFloat = 250
@@ -111,7 +111,7 @@ struct TravelJournalCardView: View {
   var imageUrl: String
 
   var isMarked: Bool {
-    myJournalsVM.bookmarkedJournals.contains(where: {$0.journalId == journalId})
+    bookmarkJournalsVM.bookmarkedJournals.contains(where: {$0.journalId == journalId})
   }
 
   init(journal: TravelJournalData) {
@@ -131,7 +131,7 @@ struct TravelJournalCardView: View {
 
       StarButton(isActive: isMarked, isYellowWhenActive: true) {
         bookmarkManager.setBookmarkState(isMarked, journalId) { _ in
-          myJournalsVM.updateBookmarkedJournals()
+          bookmarkJournalsVM.updateBookmarkedJournals()
         }
       }.offset(x: cardWidth / 2 - 25, y: -(cardHeight / 2 - 25))
 
@@ -341,12 +341,13 @@ struct FavoriteJournalCardOverlayMenuView: View {
 
 /// 태그된 여행일지 카드뷰에 오버레이 되는 메뉴 바
 struct TaggedJournalCardOverlayMenuView: View {
-  @EnvironmentObject var myJournalsVM: MyJournalsViewModel
+  @EnvironmentObject var VM: TaggedJournalListViewModel
+  @EnvironmentObject var bookmarkJournalsVM: BookmarkedJournalListViewModel
   @StateObject var bookmarkManager = JournalBookmarkManager()
   
   let journalId: Int
   var isMarked: Bool {
-    myJournalsVM.bookmarkedJournals.contains(where: {$0.journalId == journalId})
+    bookmarkJournalsVM.bookmarkedJournals.contains(where: {$0.journalId == journalId})
   }
   @State private var isShowingTaggingDeletionAlert: Bool = false
 
@@ -355,7 +356,7 @@ struct TaggedJournalCardOverlayMenuView: View {
       HStack {
         StarButton(isActive: isMarked, isYellowWhenActive: true) {
           bookmarkManager.setBookmarkState(isMarked, journalId) { _ in
-            myJournalsVM.updateBookmarkedJournals()
+            bookmarkJournalsVM.updateBookmarkedJournals()
           }
         }
         Spacer()
@@ -373,9 +374,9 @@ struct TaggedJournalCardOverlayMenuView: View {
       Button("취소") { isShowingTaggingDeletionAlert = false }
       Button("삭제") {
         isShowingTaggingDeletionAlert = false
-        myJournalsVM.deleteTagging(of: journalId) { success in
+        VM.deleteTagging(of: journalId) { success in
           if success {
-            myJournalsVM.updateTaggedJournals()
+            VM.updateTaggedJournals()
           }
         }
       }

--- a/Odya-iOS/Core/TravelJournal/MyJournals/View/MyJournalCardView.swift
+++ b/Odya-iOS/Core/TravelJournal/MyJournals/View/MyJournalCardView.swift
@@ -17,10 +17,11 @@ struct RandomJounalCardView: View {
   var journal: TravelJournalData?
   var title: String { journal?.title ?? "" }
   var travelDateString: String {
-    guard let journal = journal  else {
+    guard let journal = journal else {
       return ""
     }
-    return "\(journal.travelStartDate.dateToString(format: "yyyy.MM.dd")) ~ \(journal.travelEndDate.dateToString(format: "yyyy.MM.dd"))"
+    return
+      "\(journal.travelStartDate.dateToString(format: "yyyy.MM.dd")) ~ \(journal.travelEndDate.dateToString(format: "yyyy.MM.dd"))"
   }
   var locationString: String { "해운대 해수욕장" }
   var imageUrl: String { journal?.imageUrl ?? "" }
@@ -34,7 +35,7 @@ struct RandomJounalCardView: View {
       if journal != nil {
         AsyncImageView(
           url: imageUrl, width: cardWidth, height: cardHeight, cornerRadius: Radius.large)
-        
+
         VStack {
           Spacer()
           journalInfo
@@ -50,16 +51,16 @@ struct RandomJounalCardView: View {
       .frame(width: cardWidth, height: cardHeight)
       .foregroundColor(.odya.elevation.elev2)
       .overlay {
-//        ProgressView()
-//          .frame(width: cardWidth, height: cardHeight)
+        //        ProgressView()
+        //          .frame(width: cardWidth, height: cardHeight)
         Image("logo-lightgray")
           .resizable()
           .aspectRatio(contentMode: .fit)
           .frame(width: cardWidth / 2)
-          
+
       }
   }
-  
+
   private var shadowBox: some View {
     RoundedRectangle(cornerRadius: Radius.large)
       .foregroundColor(Color.odya.whiteopacity.baseWhiteAlpha20)
@@ -100,7 +101,7 @@ struct RandomJounalCardView: View {
 struct TravelJournalCardView: View {
   @EnvironmentObject var bookmarkJournalsVM: BookmarkedJournalListViewModel
   @StateObject var bookmarkManager = JournalBookmarkManager()
-  
+
   let cardHeight: CGFloat = 250
   let cardWidth: CGFloat = UIScreen.main.bounds.width - (GridLayout.side * 2)
 
@@ -111,7 +112,7 @@ struct TravelJournalCardView: View {
   var imageUrl: String
 
   var isMarked: Bool {
-    bookmarkJournalsVM.bookmarkedJournals.contains(where: {$0.journalId == journalId})
+    bookmarkJournalsVM.bookmarkedJournals.contains(where: { $0.journalId == journalId })
   }
 
   init(journal: TravelJournalData) {
@@ -175,9 +176,9 @@ struct TravelJournalCardView: View {
 /// 내 추억 뷰에서 즐겨찾기된 여행일지와 태그된 여행일지를 보여주기 위한 작은 카드 뷰
 struct TravelJournalSmallCardView: View {
   let cardWidth: CGFloat = 141
-//  UIScreen.main.bounds.width / 2.5
+  //  UIScreen.main.bounds.width / 2.5
   let cardHeight: CGFloat = 224
-//  (UIScreen.main.bounds.width / 2.5) * 1.5
+  //  (UIScreen.main.bounds.width / 2.5) * 1.5
 
   var title: String
   var dateString: String
@@ -320,10 +321,10 @@ struct MyReviewCardView: View {
 struct FavoriteJournalCardOverlayMenuView: View {
   @EnvironmentObject var VM: BookmarkedJournalListViewModel
   @StateObject var bookmarkManager = JournalBookmarkManager()
-  
+
   let journalId: Int
   var isMarked: Bool {
-    VM.bookmarkedJournals.contains(where: {$0.journalId == journalId})
+    VM.bookmarkedJournals.contains(where: { $0.journalId == journalId })
   }
 
   var body: some View {
@@ -346,10 +347,10 @@ struct TaggedJournalCardOverlayMenuView: View {
   @EnvironmentObject var VM: TaggedJournalListViewModel
   @EnvironmentObject var bookmarkJournalsVM: BookmarkedJournalListViewModel
   @StateObject var bookmarkManager = JournalBookmarkManager()
-  
+
   let journalId: Int
   var isMarked: Bool {
-    bookmarkJournalsVM.bookmarkedJournals.contains(where: {$0.journalId == journalId})
+    bookmarkJournalsVM.bookmarkedJournals.contains(where: { $0.journalId == journalId })
   }
   @State private var isShowingTaggingDeletionAlert: Bool = false
 
@@ -382,7 +383,7 @@ struct TaggedJournalCardOverlayMenuView: View {
           }
         }
       }
-    } // alert
+    }  // alert
   }
 }
 

--- a/Odya-iOS/Core/TravelJournal/MyJournals/View/MyJournalCardView.swift
+++ b/Odya-iOS/Core/TravelJournal/MyJournals/View/MyJournalCardView.swift
@@ -14,19 +14,16 @@ struct RandomJounalCardView: View {
   let cardHeight: CGFloat = 475
   let cardWidth: CGFloat = UIScreen.main.bounds.width - (GridLayout.side * 2)
 
-  var title: String
-  var travelDateString: String
-  var locationString: String
-  var imageUrl: String
-
-  init(journal: TravelJournalData) {
-    self.title = journal.title
-    self.travelDateString =
-      "\(journal.travelStartDate.dateToString(format: "yyyy.MM.dd")) ~ \(journal.travelEndDate.dateToString(format: "yyyy.MM.dd"))"
-    // TODO: location, placeId
-    self.locationString = "해운대 해수욕장"
-    self.imageUrl = journal.imageUrl
+  var journal: TravelJournalData?
+  var title: String { journal?.title ?? "" }
+  var travelDateString: String {
+    guard let journal = journal  else {
+      return ""
+    }
+    return "\(journal.travelStartDate.dateToString(format: "yyyy.MM.dd")) ~ \(journal.travelEndDate.dateToString(format: "yyyy.MM.dd"))"
   }
+  var locationString: String { "해운대 해수욕장" }
+  var imageUrl: String { journal?.imageUrl ?? "" }
 
   var body: some View {
     ZStack {
@@ -34,16 +31,35 @@ struct RandomJounalCardView: View {
       shadowBox.offset(y: -20)
 
       // main content
-      AsyncImageView(
-        url: imageUrl, width: cardWidth, height: cardHeight, cornerRadius: Radius.large)
-
-      VStack {
-        Spacer()
-        journalInfo
+      if journal != nil {
+        AsyncImageView(
+          url: imageUrl, width: cardWidth, height: cardHeight, cornerRadius: Radius.large)
+        
+        VStack {
+          Spacer()
+          journalInfo
+        }
+      } else {
+        defaultCardView
       }
     }
   }
 
+  private var defaultCardView: some View {
+    RoundedRectangle(cornerRadius: Radius.large)
+      .frame(width: cardWidth, height: cardHeight)
+      .foregroundColor(.odya.elevation.elev2)
+      .overlay {
+//        ProgressView()
+//          .frame(width: cardWidth, height: cardHeight)
+        Image("logo-lightgray")
+          .resizable()
+          .aspectRatio(contentMode: .fit)
+          .frame(width: cardWidth / 2)
+          
+      }
+  }
+  
   private var shadowBox: some View {
     RoundedRectangle(cornerRadius: Radius.large)
       .foregroundColor(Color.odya.whiteopacity.baseWhiteAlpha20)

--- a/Odya-iOS/Core/TravelJournal/MyJournals/View/MyJournalCardView.swift
+++ b/Odya-iOS/Core/TravelJournal/MyJournals/View/MyJournalCardView.swift
@@ -174,8 +174,10 @@ struct TravelJournalCardView: View {
 
 /// 내 추억 뷰에서 즐겨찾기된 여행일지와 태그된 여행일지를 보여주기 위한 작은 카드 뷰
 struct TravelJournalSmallCardView: View {
-  let cardWidth: CGFloat = UIScreen.main.bounds.width / 2.5
-  let cardHeight: CGFloat = (UIScreen.main.bounds.width / 2.5) * 1.5
+  let cardWidth: CGFloat = 141
+//  UIScreen.main.bounds.width / 2.5
+  let cardHeight: CGFloat = 224
+//  (UIScreen.main.bounds.width / 2.5) * 1.5
 
   var title: String
   var dateString: String

--- a/Odya-iOS/Core/TravelJournal/MyJournals/View/MyJournalCardView.swift
+++ b/Odya-iOS/Core/TravelJournal/MyJournals/View/MyJournalCardView.swift
@@ -300,12 +300,12 @@ struct MyReviewCardView: View {
 
 /// 즐겨찾기된 여행일지 카드뷰에 오버레이 되는 메뉴 바
 struct FavoriteJournalCardOverlayMenuView: View {
-  @EnvironmentObject var myJournalsVM: MyJournalsViewModel
+  @EnvironmentObject var VM: BookmarkedJournalListViewModel
   @StateObject var bookmarkManager = JournalBookmarkManager()
   
   let journalId: Int
   var isMarked: Bool {
-    myJournalsVM.bookmarkedJournals.contains(where: {$0.journalId == journalId})
+    VM.bookmarkedJournals.contains(where: {$0.journalId == journalId})
   }
 
   var body: some View {
@@ -314,7 +314,7 @@ struct FavoriteJournalCardOverlayMenuView: View {
         Spacer()
         StarButton(isActive: isMarked, isYellowWhenActive: true) {
           bookmarkManager.setBookmarkState(isMarked, journalId) { _ in
-            myJournalsVM.updateBookmarkedJournals()
+            VM.updateBookmarkedJournals()
           }
         }
       }.padding(10)

--- a/Odya-iOS/Core/TravelJournal/MyJournals/View/MyJournalsView.swift
+++ b/Odya-iOS/Core/TravelJournal/MyJournals/View/MyJournalsView.swift
@@ -17,6 +17,10 @@ struct MyJournalsView: View {
   @State private var isShowingRandomMainJournal: Bool = false
   @State private var isShowingComposeView: Bool = false
   
+  var isNoJournals: Bool {
+    !VM.isMyJournalsLoading && VM.myJournals.isEmpty
+  }
+  
   // MARK: Body
   
   var body: some View {
@@ -25,18 +29,19 @@ struct MyJournalsView: View {
         Color.odya.background.normal
           .ignoresSafeArea()
         
-        //        if VM.isMyJournalsLoading && VM.myJournals.isEmpty {
-        //          ProgressView()
-        //            .frame(maxWidth: .infinity, maxHeight: .infinity)
-        //        }
+//        if VM.isMyJournalsLoading && VM.myJournals.isEmpty {
+//          ProgressView()
+//            .frame(maxWidth: .infinity, maxHeight: .infinity)
+//        }
         
         // 작성된 여행일지가 없는 경우
-        if !VM.isMyJournalsLoading && VM.myJournals.isEmpty {
-          NoJournalView()
-        }
-        
-        else {
-          ScrollView(showsIndicators: false) {
+        ScrollView(showsIndicators: false) {
+          if isNoJournals {
+            NoJournalView()
+          }
+          
+          else {
+            
             LazyVStack(spacing: 50) {
               headerBar
                 .padding(.horizontal, GridLayout.side)
@@ -59,9 +64,13 @@ struct MyJournalsView: View {
                 .padding(.horizontal, GridLayout.side)
             }
             .padding(.vertical, 50)
+            
           }
           
-          // write button
+        } // Scroll View
+        
+        // write button
+        if !isNoJournals {
           WriteButtonWithAction(action: { isShowingComposeView = true })
             .offset(x: -(GridLayout.side), y: -(GridLayout.side))
             .fullScreenCover(isPresented: $isShowingComposeView) {

--- a/Odya-iOS/Core/TravelJournal/MyJournals/View/MyJournalsView.swift
+++ b/Odya-iOS/Core/TravelJournal/MyJournals/View/MyJournalsView.swift
@@ -12,6 +12,7 @@ struct MyJournalsView: View {
   
   @StateObject var VM = MyJournalsViewModel()
   @StateObject var bookmarkedJournalsVM = BookmarkedJournalListViewModel()
+  @StateObject var taggedJournalsVM = TaggedJournalListViewModel()
   
   @State private var isShowingRandomMainJournal: Bool = false
   @State private var isShowingBookmarkedJournals: Bool = true
@@ -45,8 +46,8 @@ struct MyJournalsView: View {
                 myBookmarkedTravelJournalList
               }
               
-              if VM.isTaggedJournalsLoading
-                  || !VM.taggedJournals.isEmpty {
+              if taggedJournalsVM.isTaggedJournalsLoading
+                  || !taggedJournalsVM.taggedJournals.isEmpty {
                 myTaggedTravelJournalList
               }
               
@@ -121,7 +122,7 @@ extension MyJournalsView {
             .navigationBarHidden(true)
         ) {
           TravelJournalCardView(journal: journal)
-            .environmentObject(VM)
+            .environmentObject(bookmarkedJournalsVM)
         }.padding(.bottom, 12)
           .onAppear {
             if let last = VM.lastIdOfMyJournals,
@@ -150,34 +151,9 @@ extension MyJournalsView {
   private var myTaggedTravelJournalList: some View {
     VStack(alignment: .leading, spacing: 0) {
       self.getSectionTitle(title: "태그된 여행일지")
-      
-      ZStack(alignment: .center) {
-        if VM.isTaggedJournalsLoading {
-          ProgressView()
-            .frame(height: 250)
-            .frame(maxWidth: .infinity)
-        }
-        
-        else {
-          ScrollView(.horizontal, showsIndicators: false) {
-            LazyHStack(spacing: 10) {
-              ForEach(VM.taggedJournals, id: \.id) { journal in
-                NavigationLink(
-                  destination: TravelJournalDetailView(journalId: journal.journalId, nickname: journal.writer.nickname)
-                    .navigationBarHidden(true)
-                ) {
-                  TravelJournalSmallCardView(
-                    title: journal.title, date: journal.travelStartDate, imageUrl: journal.mainImageUrl, writer: journal.writer)
-                }
-                .overlay {
-                  TaggedJournalCardOverlayMenuView(journalId: journal.journalId)
-                    .environmentObject(VM)
-                }
-              } // ForEach
-            }
-          } // ScrollView
-        }
-      } // ZStack
+      TaggedJournalListView()
+        .environmentObject(taggedJournalsVM)
+        .environmentObject(bookmarkedJournalsVM)
     }
   }
 }

--- a/Odya-iOS/Core/TravelJournal/MyJournals/View/MyJournalsView.swift
+++ b/Odya-iOS/Core/TravelJournal/MyJournals/View/MyJournalsView.swift
@@ -15,6 +15,7 @@ struct MyJournalsView: View {
   @StateObject var taggedJournalsVM = TaggedJournalListViewModel()
   
   @State private var isShowingRandomMainJournal: Bool = false
+  @State private var isShowingComposeView: Bool = false
   
   // MARK: Body
   
@@ -24,10 +25,10 @@ struct MyJournalsView: View {
         Color.odya.background.normal
           .ignoresSafeArea()
         
-//        if VM.isMyJournalsLoading && VM.myJournals.isEmpty {
-//          ProgressView()
-//            .frame(maxWidth: .infinity, maxHeight: .infinity)
-//        }
+        //        if VM.isMyJournalsLoading && VM.myJournals.isEmpty {
+        //          ProgressView()
+        //            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        //        }
         
         // 작성된 여행일지가 없는 경우
         if !VM.isMyJournalsLoading && VM.myJournals.isEmpty {
@@ -43,7 +44,7 @@ struct MyJournalsView: View {
                 .padding(.horizontal, GridLayout.side)
               myTravelJournalList
                 .padding(.horizontal, GridLayout.side)
-            
+              
               if bookmarkedJournalsVM.isBookmarkedJournalsLoading
                   || !bookmarkedJournalsVM.bookmarkedJournals.isEmpty {
                 myBookmarkedTravelJournalList
@@ -61,10 +62,11 @@ struct MyJournalsView: View {
           }
           
           // write button
-          NavigationLink(destination: TravelJournalComposeView().navigationBarHidden(true)) {
-            WriteButton()
-              .offset(x: -(GridLayout.side), y: -(GridLayout.side))
-          }
+          WriteButtonWithAction(action: { isShowingComposeView = true })
+            .offset(x: -(GridLayout.side), y: -(GridLayout.side))
+            .fullScreenCover(isPresented: $isShowingComposeView) {
+              TravelJournalComposeView()
+            }
         }
       } // ZStack
       .task {

--- a/Odya-iOS/Core/TravelJournal/MyJournals/View/MyJournalsView.swift
+++ b/Odya-iOS/Core/TravelJournal/MyJournals/View/MyJournalsView.swift
@@ -9,39 +9,37 @@ import SwiftUI
 
 /// 내 추억 뷰
 struct MyJournalsView: View {
-  
+
   @StateObject var VM = MyJournalsViewModel()
   @StateObject var bookmarkedJournalsVM = BookmarkedJournalListViewModel()
   @StateObject var taggedJournalsVM = TaggedJournalListViewModel()
-  
+
   @State private var isShowingRandomMainJournal: Bool = false
   @State private var isShowingComposeView: Bool = false
-  
+
   var isNoJournals: Bool {
     !VM.isMyJournalsLoading && VM.myJournals.isEmpty
   }
-  
+
   // MARK: Body
-  
+
   var body: some View {
     NavigationView {
       ZStack(alignment: .bottomTrailing) {
         Color.odya.background.normal
           .ignoresSafeArea()
-        
-//        if VM.isMyJournalsLoading && VM.myJournals.isEmpty {
-//          ProgressView()
-//            .frame(maxWidth: .infinity, maxHeight: .infinity)
-//        }
-        
+
+        //        if VM.isMyJournalsLoading && VM.myJournals.isEmpty {
+        //          ProgressView()
+        //            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        //        }
+
         // 작성된 여행일지가 없는 경우
         ScrollView(showsIndicators: false) {
           if isNoJournals {
             NoJournalView()
-          }
-          
-          else {
-            
+          } else {
+
             LazyVStack(spacing: 50) {
               headerBar
                 .padding(.horizontal, GridLayout.side)
@@ -49,26 +47,28 @@ struct MyJournalsView: View {
                 .padding(.horizontal, GridLayout.side)
               myTravelJournalList
                 .padding(.horizontal, GridLayout.side)
-              
+
               if bookmarkedJournalsVM.isBookmarkedJournalsLoading
-                  || !bookmarkedJournalsVM.bookmarkedJournals.isEmpty {
+                || !bookmarkedJournalsVM.bookmarkedJournals.isEmpty
+              {
                 myBookmarkedTravelJournalList
               }
-              
+
               if taggedJournalsVM.isTaggedJournalsLoading
-                  || !taggedJournalsVM.taggedJournals.isEmpty {
+                || !taggedJournalsVM.taggedJournals.isEmpty
+              {
                 myTaggedTravelJournalList
               }
-              
+
               myReviewList
                 .padding(.horizontal, GridLayout.side)
             }
             .padding(.vertical, 50)
-            
+
           }
-          
-        } // Scroll View
-        
+
+        }  // Scroll View
+
         // write button
         if !isNoJournals {
           WriteButtonWithAction(action: { isShowingComposeView = true })
@@ -77,7 +77,7 @@ struct MyJournalsView: View {
               TravelJournalComposeView()
             }
         }
-      } // ZStack
+      }  // ZStack
       .task {
         VM.getMyData()
         VM.initData()
@@ -89,10 +89,10 @@ struct MyJournalsView: View {
           await VM.fetchDataAsync()
         }
       }
-      
+
     }  // Navigation View
   }
-  
+
   private var headerBar: some View {
     HStack {
       Text("\(VM.nickname)님, \n지난 여행을 다시 볼까요?")
@@ -100,17 +100,18 @@ struct MyJournalsView: View {
         .foregroundColor(.odya.label.normal)
       Spacer()
       let myData = MyData()
-      ProfileImageView(of: myData.nickname, profileData: myData.profile.decodeToProileData(), size: .M)
+      ProfileImageView(
+        of: myData.nickname, profileData: myData.profile.decodeToProileData(), size: .M)
     }.padding(.bottom, 20)
   }
-  
+
   func getSectionTitle(title: String) -> some View {
     Text(title)
       .h4Style()
       .foregroundColor(.odya.label.normal)
       .padding(.bottom, 32)
   }
-  
+
   private var randomMainBoard: some View {
     VStack(spacing: 0) {
       let randomJournal = VM.myJournals.randomElement()
@@ -129,7 +130,7 @@ extension MyJournalsView {
   private var myTravelJournalList: some View {
     LazyVStack(alignment: .leading, spacing: 0) {
       self.getSectionTitle(title: "내 여행일지")
-      
+
       ForEach(VM.myJournals, id: \.id) { journal in
         NavigationLink(
           destination: TravelJournalDetailView(journalId: journal.journalId)
@@ -140,7 +141,8 @@ extension MyJournalsView {
         }.padding(.bottom, 12)
           .onAppear {
             if let last = VM.lastIdOfMyJournals,
-               last == journal.journalId {
+              last == journal.journalId
+            {
               VM.fetchMoreMyJournalsSubject.send()
             }
           }

--- a/Odya-iOS/Core/TravelJournal/MyJournals/View/MyJournalsView.swift
+++ b/Odya-iOS/Core/TravelJournal/MyJournals/View/MyJournalsView.swift
@@ -11,6 +11,9 @@ import SwiftUI
 struct MyJournalsView: View {
   
   @StateObject var VM = MyJournalsViewModel()
+  @StateObject var bookmarkedJournalsVM = BookmarkedJournalListViewModel()
+  
+  @State private var isShowingBookmarkedJournals: Bool = true
   
   // MARK: Body
   
@@ -39,8 +42,7 @@ struct MyJournalsView: View {
               randomMainBoard
               myTravelJournalList
               
-              if VM.isBookmarkedJournalsLoading
-                  || !VM.bookmarkedJournals.isEmpty {
+              if isShowingBookmarkedJournals {
                 myBookmarkedTravelJournalList
               }
               
@@ -133,39 +135,8 @@ extension MyJournalsView {
   private var myBookmarkedTravelJournalList: some View {
     VStack(alignment: .leading, spacing: 0) {
       self.getSectionTitle(title: "즐겨찾는 여행일지")
-      
-      ZStack(alignment: .center) {
-        if VM.isBookmarkedJournalsLoading {
-          ProgressView()
-            .frame(height: 250)
-            .frame(maxWidth: .infinity)
-        }
-        
-        else {
-          ScrollView(.horizontal, showsIndicators: false) {
-            LazyHStack(spacing: 10) {
-              ForEach(VM.bookmarkedJournals, id: \.id) { journal in
-                NavigationLink(
-                  destination: TravelJournalDetailView(journalId: journal.journalId, nickname: journal.writer.nickname)
-                    .navigationBarHidden(true)
-                ) {
-                  TravelJournalSmallCardView(
-                    title: journal.title, date: journal.travelStartDate, imageUrl: journal.mainImageUrl, writer: journal.writer)
-                }.overlay {
-                  FavoriteJournalCardOverlayMenuView(journalId: journal.journalId)
-                    .environmentObject(VM)
-                }
-                .onAppear {
-                  if let last = VM.lastIdOfBookmarkedJournals,
-                     last == journal.bookmarkId {
-                    VM.fetchMoreBookmarkedJournalsSubject.send()
-                  }
-                }
-              } // ForEach
-            }
-          } // ScrollView
-        }
-      } // ZStack
+      BookmarkedJournalListView($isShowingBookmarkedJournals)
+        .environmentObject(bookmarkedJournalsVM)
     }
   }
 }

--- a/Odya-iOS/Core/TravelJournal/MyJournals/View/MyJournalsView.swift
+++ b/Odya-iOS/Core/TravelJournal/MyJournals/View/MyJournalsView.swift
@@ -15,7 +15,6 @@ struct MyJournalsView: View {
   @StateObject var taggedJournalsVM = TaggedJournalListViewModel()
   
   @State private var isShowingRandomMainJournal: Bool = false
-  @State private var isShowingBookmarkedJournals: Bool = true
   
   // MARK: Body
   
@@ -39,10 +38,14 @@ struct MyJournalsView: View {
           ScrollView(showsIndicators: false) {
             LazyVStack(spacing: 50) {
               headerBar
+                .padding(.horizontal, GridLayout.side)
               randomMainBoard
+                .padding(.horizontal, GridLayout.side)
               myTravelJournalList
-              
-              if isShowingBookmarkedJournals {
+                .padding(.horizontal, GridLayout.side)
+            
+              if bookmarkedJournalsVM.isBookmarkedJournalsLoading
+                  || !bookmarkedJournalsVM.bookmarkedJournals.isEmpty {
                 myBookmarkedTravelJournalList
               }
               
@@ -52,9 +55,9 @@ struct MyJournalsView: View {
               }
               
               myReviewList
+                .padding(.horizontal, GridLayout.side)
             }
-            .padding(.horizontal, GridLayout.side)
-            .padding(.vertical, 48)
+            .padding(.vertical, 50)
           }
           
           // write button
@@ -140,8 +143,10 @@ extension MyJournalsView {
   private var myBookmarkedTravelJournalList: some View {
     VStack(alignment: .leading, spacing: 0) {
       self.getSectionTitle(title: "즐겨찾는 여행일지")
-      BookmarkedJournalListView($isShowingBookmarkedJournals)
+        .padding(.horizontal, GridLayout.side)
+      BookmarkedJournalListView()
         .environmentObject(bookmarkedJournalsVM)
+        .padding(.leading, GridLayout.side)
     }
   }
 }
@@ -151,9 +156,11 @@ extension MyJournalsView {
   private var myTaggedTravelJournalList: some View {
     VStack(alignment: .leading, spacing: 0) {
       self.getSectionTitle(title: "태그된 여행일지")
+        .padding(.horizontal, GridLayout.side)
       TaggedJournalListView()
         .environmentObject(taggedJournalsVM)
         .environmentObject(bookmarkedJournalsVM)
+        .padding(.leading, GridLayout.side)
     }
   }
 }

--- a/Odya-iOS/Core/TravelJournal/MyJournals/View/NoJournalView.swift
+++ b/Odya-iOS/Core/TravelJournal/MyJournals/View/NoJournalView.swift
@@ -9,6 +9,8 @@ import SwiftUI
 
 struct NoJournalView: View {
 
+  @State private var isShowingComposeView: Bool = false
+  
   var body: some View {
     VStack {
       Spacer()
@@ -24,15 +26,16 @@ struct NoJournalView: View {
           isActive: .active, buttonStyle: .solid, labelText: "여행일지 작성하러가기",
           labelSize: ComponentSizeType.L,
           action: {})
-
-        NavigationLink(
-          destination: TravelJournalComposeView()
-            .navigationBarHidden(true)
-        ) {
+        
+        Button(action: {isShowingComposeView = true}) {
           Rectangle()
             .foregroundColor(.clear)
             .frame(width: ComponentSizeType.L.CTAButtonWidth, height: 48)
         }
+        .fullScreenCover(isPresented: $isShowingComposeView) {
+          TravelJournalComposeView()
+            .navigationBarHidden(true)
+        } 
       }
 
       Spacer()

--- a/Odya-iOS/Core/TravelJournal/MyJournals/View/NoJournalView.swift
+++ b/Odya-iOS/Core/TravelJournal/MyJournals/View/NoJournalView.swift
@@ -10,31 +10,32 @@ import SwiftUI
 struct NoJournalView: View {
 
   @State private var isShowingComposeView: Bool = false
-  
+
   var body: some View {
     VStack {
       Spacer()
-      
+
       Image("noJournalImg")
         .resizable()
         .aspectRatio(contentMode: .fit)
-      
+
       Text("작성된 여행일지가 없어요!")
         .h6Style()
         .foregroundColor(.odya.label.normal)
         .padding(.bottom, 80)
-      
+
       CTAButton(
         isActive: .active, buttonStyle: .solid, labelText: "여행일지 작성하러가기",
         labelSize: ComponentSizeType.L,
-        action: { isShowingComposeView = true })
+        action: { isShowingComposeView = true }
+      )
       .fullScreenCover(isPresented: $isShowingComposeView) {
         TravelJournalComposeView()
           .navigationBarHidden(true)
       }
-      
+
       Spacer()
-      
+
     }
     .padding(.bottom, 80)
     .frame(width: UIScreen.main.bounds.width, height: UIScreen.main.bounds.height)

--- a/Odya-iOS/Core/TravelJournal/MyJournals/View/NoJournalView.swift
+++ b/Odya-iOS/Core/TravelJournal/MyJournals/View/NoJournalView.swift
@@ -14,33 +14,39 @@ struct NoJournalView: View {
   var body: some View {
     VStack {
       Spacer()
+      
       Image("noJournalImg")
         .resizable()
-        .scaledToFit()
+        .aspectRatio(contentMode: .fit)
+      
       Text("작성된 여행일지가 없어요!")
         .h6Style()
         .foregroundColor(.odya.label.normal)
         .padding(.bottom, 80)
-      ZStack {
-        CTAButton(
-          isActive: .active, buttonStyle: .solid, labelText: "여행일지 작성하러가기",
-          labelSize: ComponentSizeType.L,
-          action: {})
-        
-        Button(action: {isShowingComposeView = true}) {
-          Rectangle()
-            .foregroundColor(.clear)
-            .frame(width: ComponentSizeType.L.CTAButtonWidth, height: 48)
-        }
-        .fullScreenCover(isPresented: $isShowingComposeView) {
-          TravelJournalComposeView()
-            .navigationBarHidden(true)
-        } 
+      
+      CTAButton(
+        isActive: .active, buttonStyle: .solid, labelText: "여행일지 작성하러가기",
+        labelSize: ComponentSizeType.L,
+        action: { isShowingComposeView = true })
+      .fullScreenCover(isPresented: $isShowingComposeView) {
+        TravelJournalComposeView()
+          .navigationBarHidden(true)
       }
-
+      
       Spacer()
-    }.background(Color.odya.background.normal)
+      
+    }
+    .padding(.bottom, 80)
+    .frame(width: UIScreen.main.bounds.width, height: UIScreen.main.bounds.height)
+    .background(Color.odya.background.normal)
+    .ignoresSafeArea()
 
   }
 
+}
+
+struct NoJournalView_Previews: PreviewProvider {
+  static var previews: some View {
+    NoJournalView()
+  }
 }

--- a/Odya-iOS/Core/TravelJournal/MyJournals/View/TaggedJournalListView.swift
+++ b/Odya-iOS/Core/TravelJournal/MyJournals/View/TaggedJournalListView.swift
@@ -10,41 +10,44 @@ import SwiftUI
 struct TaggedJournalListView: View {
   @EnvironmentObject var VM: TaggedJournalListViewModel
   @EnvironmentObject var bookmarkedJournalsVM: BookmarkedJournalListViewModel
-  
+
   var body: some View {
     ZStack(alignment: .center) {
       if VM.isTaggedJournalsLoading
-          && VM.taggedJournals.isEmpty {
+        && VM.taggedJournals.isEmpty
+      {
         ProgressView()
           .frame(height: 224)
           .frame(maxWidth: .infinity)
-      }
-      
-      else {
+      } else {
         ScrollView(.horizontal, showsIndicators: false) {
           LazyHStack(spacing: 10) {
             ForEach(VM.taggedJournals, id: \.id) { journal in
               linkToJournalDetail(journal)
                 .onAppear {
                   if let last = VM.lastIdOfTaggedJournals,
-                     last == journal.journalId {
+                    last == journal.journalId
+                  {
                     VM.fetchMoreTaggedJournalsSubject.send()
                   }
                 }
-            } // ForEach
+            }  // ForEach
           }
-        } // ScrollView
+        }  // ScrollView
       }
-    } // ZStack
+    }  // ZStack
   }
-  
+
   private func linkToJournalDetail(_ journal: TaggedJournalData) -> some View {
     NavigationLink(
-      destination: TravelJournalDetailView(journalId: journal.journalId, nickname: journal.writer.nickname)
-        .navigationBarHidden(true)
+      destination: TravelJournalDetailView(
+        journalId: journal.journalId, nickname: journal.writer.nickname
+      )
+      .navigationBarHidden(true)
     ) {
       TravelJournalSmallCardView(
-        title: journal.title, date: journal.travelStartDate, imageUrl: journal.mainImageUrl, writer: journal.writer)
+        title: journal.title, date: journal.travelStartDate, imageUrl: journal.mainImageUrl,
+        writer: journal.writer)
     }
     .overlay {
       TaggedJournalCardOverlayMenuView(journalId: journal.journalId)

--- a/Odya-iOS/Core/TravelJournal/MyJournals/View/TaggedJournalListView.swift
+++ b/Odya-iOS/Core/TravelJournal/MyJournals/View/TaggedJournalListView.swift
@@ -13,9 +13,10 @@ struct TaggedJournalListView: View {
   
   var body: some View {
     ZStack(alignment: .center) {
-      if VM.isTaggedJournalsLoading {
+      if VM.isTaggedJournalsLoading
+          && VM.taggedJournals.isEmpty {
         ProgressView()
-          .frame(height: 250)
+          .frame(height: 224)
           .frame(maxWidth: .infinity)
       }
       

--- a/Odya-iOS/Core/TravelJournal/MyJournals/View/TaggedJournalListView.swift
+++ b/Odya-iOS/Core/TravelJournal/MyJournals/View/TaggedJournalListView.swift
@@ -1,0 +1,54 @@
+//
+//  TaggedJournalListView.swift
+//  Odya-iOS
+//
+//  Created by Heeoh Son on 2023/12/14.
+//
+
+import SwiftUI
+
+struct TaggedJournalListView: View {
+  @EnvironmentObject var VM: TaggedJournalListViewModel
+  @EnvironmentObject var bookmarkedJournalsVM: BookmarkedJournalListViewModel
+  
+  var body: some View {
+    ZStack(alignment: .center) {
+      if VM.isTaggedJournalsLoading {
+        ProgressView()
+          .frame(height: 250)
+          .frame(maxWidth: .infinity)
+      }
+      
+      else {
+        ScrollView(.horizontal, showsIndicators: false) {
+          LazyHStack(spacing: 10) {
+            ForEach(VM.taggedJournals, id: \.id) { journal in
+              linkToJournalDetail(journal)
+                .onAppear {
+                  if let last = VM.lastIdOfTaggedJournals,
+                     last == journal.journalId {
+                    VM.fetchMoreTaggedJournalsSubject.send()
+                  }
+                }
+            } // ForEach
+          }
+        } // ScrollView
+      }
+    } // ZStack
+  }
+  
+  private func linkToJournalDetail(_ journal: TaggedJournalData) -> some View {
+    NavigationLink(
+      destination: TravelJournalDetailView(journalId: journal.journalId, nickname: journal.writer.nickname)
+        .navigationBarHidden(true)
+    ) {
+      TravelJournalSmallCardView(
+        title: journal.title, date: journal.travelStartDate, imageUrl: journal.mainImageUrl, writer: journal.writer)
+    }
+    .overlay {
+      TaggedJournalCardOverlayMenuView(journalId: journal.journalId)
+        .environmentObject(VM)
+        .environmentObject(bookmarkedJournalsVM)
+    }
+  }
+}

--- a/Odya-iOS/Core/TravelJournal/MyJournals/ViewModel/BookmarkedJournalListViewModel.swift
+++ b/Odya-iOS/Core/TravelJournal/MyJournals/ViewModel/BookmarkedJournalListViewModel.swift
@@ -5,10 +5,10 @@
 //  Created by Heeoh Son on 2023/12/14.
 //
 
-import SwiftUI
-import Moya
-import CombineMoya
 import Combine
+import CombineMoya
+import Moya
+import SwiftUI
 
 class BookmarkedJournalListViewModel: ObservableObject {
   // moya
@@ -21,28 +21,29 @@ class BookmarkedJournalListViewModel: ObservableObject {
   private var subscription = Set<AnyCancellable>()
 
   // MARK: Properties
-  
+
   // data
   @Published var bookmarkedJournals: [BookmarkedJournalData] = []
 
   // loading flag
   @Published var isBookmarkedJournalsLoading: Bool = false
-  
+
   // infinite scroll
   @Published var lastIdOfBookmarkedJournals: Int? = nil
   var hasNextBookmarkedJournals: Bool = true
   var fetchMoreBookmarkedJournalsSubject = PassthroughSubject<(), Never>()
 
   // MARK: Init
-  
+
   init() {
     fetchDataAsync()
-    
+
     fetchMoreBookmarkedJournalsSubject
       .sink { [weak self] _ in
         guard let self = self,
-              !self.isBookmarkedJournalsLoading,
-              self.hasNextBookmarkedJournals else {
+          !self.isBookmarkedJournalsLoading,
+          self.hasNextBookmarkedJournals
+        else {
           return
         }
         self.getBookmarkedJournals()
@@ -53,7 +54,8 @@ class BookmarkedJournalListViewModel: ObservableObject {
 
   func fetchDataAsync() {
     if isBookmarkedJournalsLoading
-        || !hasNextBookmarkedJournals {
+      || !hasNextBookmarkedJournals
+    {
       return
     }
 
@@ -71,7 +73,9 @@ class BookmarkedJournalListViewModel: ObservableObject {
 
   private func getBookmarkedJournals() {
     self.isBookmarkedJournalsLoading = true
-    journalBookmarkProvider.requestPublisher(.getBookmarkedJournals(size: nil, lastId: self.lastIdOfBookmarkedJournals))
+    journalBookmarkProvider.requestPublisher(
+      .getBookmarkedJournals(size: nil, lastId: self.lastIdOfBookmarkedJournals)
+    )
     .sink { completion in
       switch completion {
       case .finished:

--- a/Odya-iOS/Core/TravelJournal/MyJournals/ViewModel/BookmarkedJournalListViewModel.swift
+++ b/Odya-iOS/Core/TravelJournal/MyJournals/ViewModel/BookmarkedJournalListViewModel.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-
 import Moya
 import CombineMoya
 import Combine
@@ -42,6 +41,7 @@ class BookmarkedJournalListViewModel: ObservableObject {
     fetchMoreBookmarkedJournalsSubject
       .sink { [weak self] _ in
         guard let self = self,
+              !self.isBookmarkedJournalsLoading,
               self.hasNextBookmarkedJournals else {
           return
         }

--- a/Odya-iOS/Core/TravelJournal/MyJournals/ViewModel/BookmarkedJournalListViewModel.swift
+++ b/Odya-iOS/Core/TravelJournal/MyJournals/ViewModel/BookmarkedJournalListViewModel.swift
@@ -1,0 +1,104 @@
+//
+//  BookmarkedJournalListViewModel.swift
+//  Odya-iOS
+//
+//  Created by Heeoh Son on 2023/12/14.
+//
+
+import SwiftUI
+
+import Moya
+import CombineMoya
+import Combine
+
+class BookmarkedJournalListViewModel: ObservableObject {
+  // moya
+  @AppStorage("WeITAuthToken") var idToken: String?
+  private let logPlugin: PluginType = NetworkLoggerPlugin(
+    configuration: .init(logOptions: .verbose))
+  private lazy var authPlugin = AccessTokenPlugin { [self] _ in idToken ?? "" }
+  private lazy var journalBookmarkProvider = MoyaProvider<TravelJournalBookmarkRouter>(
+    session: Session(interceptor: AuthInterceptor.shared), plugins: [logPlugin, authPlugin])
+  private var subscription = Set<AnyCancellable>()
+
+  // MARK: Properties
+  
+  // data
+  @Published var bookmarkedJournals: [BookmarkedJournalData] = []
+
+  // loading flag
+  @Published var isBookmarkedJournalsLoading: Bool = false
+  
+  // infinite scroll
+  @Published var lastIdOfBookmarkedJournals: Int? = nil
+  var hasNextBookmarkedJournals: Bool = true
+  var fetchMoreBookmarkedJournalsSubject = PassthroughSubject<(), Never>()
+
+  // MARK: Init
+  
+  init() {
+    fetchDataAsync()
+    
+    fetchMoreBookmarkedJournalsSubject
+      .sink { [weak self] _ in
+        guard let self = self,
+              self.hasNextBookmarkedJournals else {
+          return
+        }
+        self.getBookmarkedJournals()
+      }.store(in: &subscription)
+  }
+
+  // MARK: Get Bookmarked Journals
+
+  func fetchDataAsync() {
+    if isBookmarkedJournalsLoading
+        || !hasNextBookmarkedJournals {
+      return
+    }
+
+    getBookmarkedJournals()
+  }
+
+  func updateBookmarkedJournals() {
+    isBookmarkedJournalsLoading = false
+    hasNextBookmarkedJournals = true
+    lastIdOfBookmarkedJournals = nil
+    bookmarkedJournals = []
+
+    getBookmarkedJournals()
+  }
+
+  private func getBookmarkedJournals() {
+    self.isBookmarkedJournalsLoading = true
+    journalBookmarkProvider.requestPublisher(.getBookmarkedJournals(size: nil, lastId: self.lastIdOfBookmarkedJournals))
+    .sink { completion in
+      switch completion {
+      case .finished:
+        self.isBookmarkedJournalsLoading = false
+      case .failure(let error):
+        self.isBookmarkedJournalsLoading = false
+        self.processErrorResponse(error)
+      }
+    } receiveValue: { response in
+      do {
+        let responseData = try response.map(BookmarkedJournalList.self)
+        self.hasNextBookmarkedJournals = responseData.hasNext
+        self.bookmarkedJournals += responseData.content
+        self.lastIdOfBookmarkedJournals = responseData.content.last?.bookmarkId ?? nil
+      } catch {
+        print("BookmarkedJournalList decoding error")
+        return
+      }
+    }.store(in: &subscription)
+  }
+
+  // MARK: error handling
+  private func processErrorResponse(_ error: MoyaError) {
+    if let errorData = try? error.response?.map(ErrorData.self) {
+      print("in profile view model - \(errorData.message)")
+    } else {  // unknown error
+      print("in profile view model - \(error)")
+    }
+  }
+}

--- a/Odya-iOS/Core/TravelJournal/MyJournals/ViewModel/TaggedJournalListViewModel.swift
+++ b/Odya-iOS/Core/TravelJournal/MyJournals/ViewModel/TaggedJournalListViewModel.swift
@@ -1,0 +1,119 @@
+//
+//  TaggedJournalListViewModel.swift
+//  Odya-iOS
+//
+//  Created by Heeoh Son on 2023/12/14.
+//
+
+import SwiftUI
+import Moya
+import CombineMoya
+import Combine
+
+class TaggedJournalListViewModel: ObservableObject {
+  // moya
+  @AppStorage("WeITAuthToken") var idToken: String?
+  private let logPlugin: PluginType = NetworkLoggerPlugin(
+    configuration: .init(logOptions: .verbose))
+  private lazy var authPlugin = AccessTokenPlugin { [self] _ in idToken ?? "" }
+  private lazy var journalTagProvider = MoyaProvider<TravelJournalTagRouter>(
+    session: Session(interceptor: AuthInterceptor.shared), plugins: [logPlugin, authPlugin])
+  private var subscription = Set<AnyCancellable>()
+  
+  @Published var taggedJournals: [TaggedJournalData] = []
+
+  // loading flag
+  var isTaggedJournalsLoading: Bool = false
+  var isTravelMateDeleting: Bool = false
+  
+  // infinite Scroll
+  @Published var lastIdOfTaggedJournals: Int? = nil
+  var hasNextTaggedJournals: Bool = true
+  var fetchMoreTaggedJournalsSubject = PassthroughSubject<(), Never>()
+  
+  init() {
+    fetchDataAsync()
+    
+    fetchMoreTaggedJournalsSubject
+      .sink { [weak self] _ in
+        guard let self = self,
+              !self.isTaggedJournalsLoading,
+              self.hasNextTaggedJournals else {
+          return
+        }
+        self.getTaggedJournals()
+      }.store(in: &subscription)
+  }
+  
+  func fetchDataAsync() {
+    if isTaggedJournalsLoading
+        || !hasNextTaggedJournals {
+      return
+    }
+
+    getTaggedJournals()
+  }
+  
+  func updateTaggedJournals() {
+    isTaggedJournalsLoading = false
+    hasNextTaggedJournals = true
+    lastIdOfTaggedJournals = nil
+    taggedJournals = []
+    
+    getTaggedJournals()
+  }
+
+  private func getTaggedJournals() {
+    self.isTaggedJournalsLoading = true
+    journalTagProvider.requestPublisher(.getTaggedJournals(size: nil, lastId: self.lastIdOfTaggedJournals))
+    .sink { completion in
+      switch completion {
+      case .finished:
+        self.isTaggedJournalsLoading = false
+      case .failure(let error):
+        self.isTaggedJournalsLoading = false
+        self.processErrorResponse(error)
+      }
+    } receiveValue: { response in
+      do {
+        let responseData = try response.map(TaggedJournalList.self)
+        self.hasNextTaggedJournals = responseData.hasNext
+        self.taggedJournals += responseData.content
+        self.lastIdOfTaggedJournals = responseData.content.last?.journalId
+      } catch {
+        return
+      }
+    }.store(in: &subscription)
+  }
+
+  // MARK: Delete Tag
+  func deleteTagging(of journalId: Int, completion: @escaping (Bool) -> Void) {
+    if isTravelMateDeleting {
+      return
+    }
+    
+    isTravelMateDeleting = true
+    journalTagProvider.requestPublisher(.deleteTravelMates(journalId: journalId))
+    .sink { apiCompletion in
+      switch apiCompletion {
+      case .finished:
+        self.isTravelMateDeleting = false
+        completion(true)
+      case .failure(let error):
+        self.isTravelMateDeleting = false
+        self.processErrorResponse(error)
+        completion(false)
+      }
+    } receiveValue: { _ in }
+    .store(in: &subscription)
+  }
+  
+  // MARK: error handling
+  private func processErrorResponse(_ error: MoyaError) {
+    if let errorData = try? error.response?.map(ErrorData.self) {
+      print("in profile view model - \(errorData.message)")
+    } else {  // unknown error
+      print("in profile view model - \(error)")
+    }
+  }
+}

--- a/Odya-iOS/Core/TravelJournal/MyJournals/ViewModel/TravelJournalViewModel.swift
+++ b/Odya-iOS/Core/TravelJournal/MyJournals/ViewModel/TravelJournalViewModel.swift
@@ -30,23 +30,24 @@ class MyJournalsViewModel: ObservableObject {
 
   // loading flag
   @Published var isMyJournalsLoading: Bool = false
-  
+
   // infinite Scroll
   @Published var lastIdOfMyJournals: Int? = nil
   var hasNextMyJournals: Bool = true
   var fetchMoreMyJournalsSubject = PassthroughSubject<(), Never>()
-  
+
   init() {
     fetchMoreMyJournalsSubject
       .sink { [weak self] _ in
         guard let self = self,
-              let idToken = self.idToken else {
+          let idToken = self.idToken
+        else {
           return
         }
         self.getMyJournals(idToken: idToken)
       }.store(in: &subscription)
   }
-  
+
   // MARK: Get My Data
 
   /// user defaults에서 유저 정보 가져옴

--- a/Odya-iOS/Core/TravelJournal/MyJournals/ViewModel/TravelJournalViewModel.swift
+++ b/Odya-iOS/Core/TravelJournal/MyJournals/ViewModel/TravelJournalViewModel.swift
@@ -50,14 +50,7 @@ class MyJournalsViewModel: ObservableObject {
   var fetchMoreTaggedJournalsSubject = PassthroughSubject<(), Never>()
   
   init() {
-    fetchMoreBookmarkedJournalsSubject
-      .sink { [weak self] _ in
-        guard let self = self,
-              self.hasNextBookmarkedJournals else {
-          return
-        }
-        self.getBookmarkedJournals(idToken: self.idToken ?? "")
-      }.store(in: &subscription)
+    
   }
   
   // MARK: Get My Data
@@ -97,7 +90,7 @@ class MyJournalsViewModel: ObservableObject {
     }
 
     getMyJournals(idToken: idToken)
-    getBookmarkedJournals(idToken: idToken)
+//    getBookmarkedJournals(idToken: idToken)
     getTaggedJournals(idToken: idToken)
   }
 

--- a/Odya-iOS/Core/TravelJournal/MyJournals/ViewModel/TravelJournalViewModel.swift
+++ b/Odya-iOS/Core/TravelJournal/MyJournals/ViewModel/TravelJournalViewModel.swift
@@ -37,7 +37,7 @@ class MyJournalsViewModel: ObservableObject {
   var isTravelMateDeleting: Bool = false
   
   // infinite Scroll
-  var lastIdOfMyJournals: Int? = nil
+  @Published var lastIdOfMyJournals: Int? = nil
   var hasNextMyJournals: Bool = true
   var fetchMoreMyJournalsSubject = PassthroughSubject<(), Never>()
   
@@ -50,7 +50,14 @@ class MyJournalsViewModel: ObservableObject {
   var fetchMoreTaggedJournalsSubject = PassthroughSubject<(), Never>()
   
   init() {
-    
+    fetchMoreMyJournalsSubject
+      .sink { [weak self] _ in
+        guard let self = self,
+              let idToken = self.idToken else {
+          return
+        }
+        self.getMyJournals(idToken: idToken)
+      }.store(in: &subscription)
   }
   
   // MARK: Get My Data

--- a/Odya-iOS/Core/TravelJournal/TravelJournalCompose/View/TravelJournalComposeView.swift
+++ b/Odya-iOS/Core/TravelJournal/TravelJournalCompose/View/TravelJournalComposeView.swift
@@ -143,7 +143,7 @@ struct TravelJournalComposeView: View {
       ZStack {
         Color.odya.background.normal
           .edgesIgnoringSafeArea(.bottom)
-        
+
         VStack(spacing: 0) {
           ZStack {
             CustomNavigationBar(title: "여행일지 작성하기")
@@ -153,8 +153,8 @@ struct TravelJournalComposeView: View {
               }.padding(.leading, 8)
               Spacer()
             }
-          }.background( Color.odya.background.normal)
-          
+          }.background(Color.odya.background.normal)
+
           ScrollView(showsIndicators: false) {
             VStack(spacing: 0) {
               TravelJournalInfoEditView(isDatePickerVisible: $isDatePickerVisible)
@@ -166,8 +166,7 @@ struct TravelJournalComposeView: View {
             }
           }
         }
-        
-        
+
         // 여행일지 날짜 선택 뷰
         if isDatePickerVisible {
           TravelDatePickerView(
@@ -177,7 +176,7 @@ struct TravelJournalComposeView: View {
           .frame(maxHeight: .infinity)
           .background(Color.odya.blackopacity.baseBlackAlpha80)
         }
-        
+
         // 데일리 일정 날짜 선태 뷰
         if isDailyDatePickerVisible {
           DailyJournalDatePicker(
@@ -219,7 +218,7 @@ struct TravelJournalComposeView: View {
       }
     }
   }  // body
-  
+
   private var divider: some View {
     HStack(spacing: 0) {}
       .frame(maxWidth: .infinity)
@@ -364,4 +363,3 @@ struct TravelJournalEditView_Previews: PreviewProvider {
     TravelJournalComposeView()
   }
 }
- 

--- a/Odya-iOS/Core/TravelJournal/TravelJournalCompose/View/TravelJournalComposeView.swift
+++ b/Odya-iOS/Core/TravelJournal/TravelJournalCompose/View/TravelJournalComposeView.swift
@@ -139,12 +139,12 @@ struct TravelJournalComposeView: View {
   // MARK: Body
 
   var body: some View {
-    ZStack {
-      Color.odya.background.normal
-        .edgesIgnoringSafeArea(.bottom)
-
-      NavigationView {
-        VStack {
+    NavigationView {
+      ZStack {
+        Color.odya.background.normal
+          .edgesIgnoringSafeArea(.bottom)
+        
+        VStack(spacing: 0) {
           ZStack {
             CustomNavigationBar(title: "여행일지 작성하기")
             HStack {
@@ -153,69 +153,79 @@ struct TravelJournalComposeView: View {
               }.padding(.leading, 8)
               Spacer()
             }
-          }
-
+          }.background( Color.odya.background.normal)
+          
           ScrollView(showsIndicators: false) {
-            VStack(spacing: 8) {
+            VStack(spacing: 0) {
               TravelJournalInfoEditView(isDatePickerVisible: $isDatePickerVisible)
                 .environmentObject(journalComposeVM)
+              divider
               jounalListEditSection
+              divider
               travelJournalRegisterSection
             }
-            .background(Color.odya.blackopacity.baseBlackAlpha50)
           }
         }
+        
+        
+        // 여행일지 날짜 선택 뷰
+        if isDatePickerVisible {
+          TravelDatePickerView(
+            journalComposeVM: journalComposeVM, isDatePickerVisible: $isDatePickerVisible
+          )
+          .padding(GridLayout.side)
+          .frame(maxHeight: .infinity)
+          .background(Color.odya.blackopacity.baseBlackAlpha80)
+        }
+        
+        // 데일리 일정 날짜 선태 뷰
+        if isDailyDatePickerVisible {
+          DailyJournalDatePicker(
+            journalComposeVM: journalComposeVM, isDatePickerVisible: $isDailyDatePickerVisible
+          )
+          .padding(GridLayout.side)
+          .frame(maxHeight: .infinity)
+          .background(Color.odya.blackopacity.baseBlackAlpha80)
+        }
       }
-
-      // 여행일지 날짜 선택 뷰
-      if isDatePickerVisible {
-        TravelDatePickerView(
-          journalComposeVM: journalComposeVM, isDatePickerVisible: $isDatePickerVisible
-        )
-        .padding(GridLayout.side)
-        .background(Color.odya.blackopacity.baseBlackAlpha80)
+      .onAppear {
+        journalComposeVM.addDailyJournal()
       }
-
-      // 데일리 일정 날짜 선태 뷰
-      if isDailyDatePickerVisible {
-        DailyJournalDatePicker(
-          journalComposeVM: journalComposeVM, isDatePickerVisible: $isDailyDatePickerVisible
-        )
-        .padding(GridLayout.side)
-        .frame(maxHeight: .infinity)
-        .background(Color.odya.blackopacity.baseBlackAlpha80)
-      }
-    }
-    .onAppear {
-      journalComposeVM.addDailyJournal()
-    }
-    .confirmationDialog("", isPresented: $isDismissAlertVisible) {
-      Button("임시저장") { print("임시저장 클릭") }
-      Button("작성취소", role: .destructive) {
-        print("작성취소 클릭")
-        dismiss()
-      }
-      Button("취소", role: .cancel) { print("취소 클릭") }
-    } message: {
-      Text("작성 중인 글을 취소하시겠습니까?\n작성 취소 선택시, 작성된 글은 저장되지 않습니다.")
-    }
-    .alert("작성한 여행일지를\n등록하시겠습니까?", isPresented: $isRegisterAlertVisible) {
-      Button("취소") {
-        isRegisterAlertVisible = false
-      }
-      Button("등록") {
-        isRegisterAlertVisible = false
-        // 검사
-        if journalComposeVM.validateTravelJournal() {
-          // api
-          Task {
-            await journalComposeVM.registerTravelJournal()
-          }
+      .confirmationDialog("", isPresented: $isDismissAlertVisible) {
+        Button("임시저장") { print("임시저장 클릭") }
+        Button("작성취소", role: .destructive) {
+          print("작성취소 클릭")
           dismiss()
+        }
+        Button("취소", role: .cancel) { print("취소 클릭") }
+      } message: {
+        Text("작성 중인 글을 취소하시겠습니까?\n작성 취소 선택시, 작성된 글은 저장되지 않습니다.")
+      }
+      .alert("작성한 여행일지를\n등록하시겠습니까?", isPresented: $isRegisterAlertVisible) {
+        Button("취소") {
+          isRegisterAlertVisible = false
+        }
+        Button("등록") {
+          isRegisterAlertVisible = false
+          // 검사
+          if journalComposeVM.validateTravelJournal() {
+            // api
+            Task {
+              await journalComposeVM.registerTravelJournal()
+            }
+            dismiss()
+          }
         }
       }
     }
   }  // body
+  
+  private var divider: some View {
+    HStack(spacing: 0) {}
+      .frame(maxWidth: .infinity)
+      .frame(height: 8)
+      .background(Color.odya.blackopacity.baseBlackAlpha50)
+  }
 
   // MARK: Journal List Edit Section
   private var jounalListEditSection: some View {
@@ -354,3 +364,4 @@ struct TravelJournalEditView_Previews: PreviewProvider {
     TravelJournalComposeView()
   }
 }
+ 

--- a/Odya-iOS/Core/TravelJournal/TravelJournalCompose/View/TravelMateSelectorView.swift
+++ b/Odya-iOS/Core/TravelJournal/TravelJournalCompose/View/TravelMateSelectorView.swift
@@ -166,31 +166,34 @@ struct TravelMateSelectorView: View {
       VStack(spacing: 16) {
         ForEach(displayedFollowingUsers) { user in
           HStack {
-            UserIdentityLink(userId: user.userId,
-                             nickname: user.nickname,
-                             profileUrl: user.profile.profileUrl,
-                             isFollowing: true)
+            UserIdentityLink(
+              userId: user.userId,
+              nickname: user.nickname,
+              profileUrl: user.profile.profileUrl,
+              isFollowing: true)
             Spacer()
-            CustomIconButton("plus-circle",
-                             color: isSelected(user.userId) ? .odya.label.inactive : .odya.brand.primary) {
+            CustomIconButton(
+              "plus-circle",
+              color: isSelected(user.userId) ? .odya.label.inactive : .odya.brand.primary
+            ) {
               if selectedTravelMates.count >= 10 {
                 isShowingTooManyMatesAlert = true
               } else {
                 selectedTravelMates.insert(user, at: 0)
               }
             }
-//            IconButton("plus-circle") {
-//              if selectedTravelMates.count >= 10 {
-//                isShowingTooManyMatesAlert = true
-//              } else {
-//                selectedTravelMates.insert(user, at: 0)
-//              }
-//            }
-//            .colorMultiply(
-//              selectedTravelMates.contains { mate in
-//                mate.userId == user.userId
-//              } ? .odya.label.inactive : .odya.brand.primary
-//            )
+            //            IconButton("plus-circle") {
+            //              if selectedTravelMates.count >= 10 {
+            //                isShowingTooManyMatesAlert = true
+            //              } else {
+            //                selectedTravelMates.insert(user, at: 0)
+            //              }
+            //            }
+            //            .colorMultiply(
+            //              selectedTravelMates.contains { mate in
+            //                mate.userId == user.userId
+            //              } ? .odya.label.inactive : .odya.brand.primary
+            //            )
             .frame(height: 36)
             .disabled(isSelected(user.userId))
           }.frame(height: 36)

--- a/Odya-iOS/Core/TravelJournal/TravelJournalCompose/ViewModel/TravelJournalEditViewModel.swift
+++ b/Odya-iOS/Core/TravelJournal/TravelJournalCompose/ViewModel/TravelJournalEditViewModel.swift
@@ -105,12 +105,12 @@ class JournalComposeViewModel: ObservableObject {
     }
 
     // 여행 이미지 리사이징이 제대로 처리 안된 경우
-    if dailyJournalList.flatMap({$0.selectedImages}).contains(where: {
+    if dailyJournalList.flatMap({ $0.selectedImages }).contains(where: {
       max($0.image.size.width, $0.image.size.height) > 1024
     }) {
       return false
     }
-    
+
     // 여행 일지의 시작일이 여행 일지의 종료일보다 늦을 경우
     if startDate > endDate {
       return false
@@ -191,9 +191,9 @@ class JournalComposeViewModel: ObservableObject {
       // webp 변환하기
       let images = dailyJournalList.flatMap { $0.selectedImages }
       let webPImages = await webPImageManager.processImages(images: images)
-      
-//      print(images.count)
-//      print(webPImages.count)
+
+      //      print(images.count)
+      //      print(webPImages.count)
 
       // api 호출
       _ = try await createJournalAPI(idToken: idToken, webpImages: webPImages)

--- a/Odya-iOS/Core/TravelJournal/TravelJournalDetail/View/DailyJournalView.swift
+++ b/Odya-iOS/Core/TravelJournal/TravelJournalDetail/View/DailyJournalView.swift
@@ -12,6 +12,7 @@ struct DailyJournalView: View {
   @EnvironmentObject var journalDetailVM: TravelJournalDetailViewModel
   
   // journal data
+  let journal: TravelJournalDetailData
   let journalId: Int
   let dailyJournal: DailyJournal
   let dateString: String
@@ -32,6 +33,8 @@ struct DailyJournalView: View {
 
   /// 데일리 일정 내용이 펼쳐져 있는지 여부
   @State private var isExpanded: Bool = false
+  
+  @State private var isShowingEditView: Bool = false
 
   /// 데일리 일정 삭제 확인 알림 화면 표시 여부
   @State private var isShowingJournalDeletionAlert: Bool = false
@@ -42,8 +45,9 @@ struct DailyJournalView: View {
   /// 데일리 일정 삭제 실패 메시지
   @State private var failureMessage: String = ""
 
-  init(journalId: Int, dailyJournal: DailyJournal) {
-    self.journalId = journalId
+  init(journal: TravelJournalDetailData, dailyJournal: DailyJournal) {
+    self.journal = journal
+    self.journalId = journal.journalId
     self.dailyJournal = dailyJournal
 
     self.dateString = dailyJournal.travelDate.dateToString(format: "yyyy.MM.dd")
@@ -73,13 +77,16 @@ struct DailyJournalView: View {
           Menu {
             Button("편집하기") {
               print("edit")
-              journalDetailVM.editedDailyJournal = dailyJournal
+              isShowingEditView = true
             }
             Button("삭제하기", role: .destructive) {
               isShowingJournalDeletionAlert = true
             }
           } label: {
             Image("menu-kebob")
+          }
+          .fullScreenCover(isPresented: $isShowingEditView) {
+            DailyJournalEditView(journal: journal, editedJournal: dailyJournal)
           }
         }
       }

--- a/Odya-iOS/Core/TravelJournal/TravelJournalDetail/View/DailyJournalView.swift
+++ b/Odya-iOS/Core/TravelJournal/TravelJournalDetail/View/DailyJournalView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct DailyJournalView: View {
 
   @EnvironmentObject var journalDetailVM: TravelJournalDetailViewModel
-  
+
   // journal data
   let journal: TravelJournalDetailData
   let journalId: Int
@@ -33,7 +33,7 @@ struct DailyJournalView: View {
 
   /// 데일리 일정 내용이 펼쳐져 있는지 여부
   @State private var isExpanded: Bool = false
-  
+
   @State private var isShowingEditView: Bool = false
 
   /// 데일리 일정 삭제 확인 알림 화면 표시 여부

--- a/Odya-iOS/Core/TravelJournal/TravelJournalDetail/View/OffsettableScrollView.swift
+++ b/Odya-iOS/Core/TravelJournal/TravelJournalDetail/View/OffsettableScrollView.swift
@@ -51,7 +51,8 @@ struct OffsettableScrollView<T: View>: View {
       .coordinateSpace(name: "ScrollViewOrigin")
       .onPreferenceChange(
         OffsetPreferenceKey.self,
-        perform: onOffsetChanged)
+        perform: onOffsetChanged
+      )
       .onChange(of: shouldScrollToTop) { shouldScrollToTop in
         if shouldScrollToTop {
           withAnimation(.default) {

--- a/Odya-iOS/Core/TravelJournal/TravelJournalDetail/View/TravelJournalDetailBottomSheet.swift
+++ b/Odya-iOS/Core/TravelJournal/TravelJournalDetail/View/TravelJournalDetailBottomSheet.swift
@@ -47,7 +47,7 @@ struct JournalDetailBottomSheet: View {
 
   var body: some View {
     ZStack {
-      OffsettableScrollView { point in
+      OffsettableScrollView(shouldScrollToTop: $bottomSheetVM.scrollToTop) { point in
         if point.y != 0 {
           bottomSheetVM.isScrollAtTop = point.y > 0
         }

--- a/Odya-iOS/Core/TravelJournal/TravelJournalDetail/View/TravelJournalDetailBottomSheet.swift
+++ b/Odya-iOS/Core/TravelJournal/TravelJournalDetail/View/TravelJournalDetailBottomSheet.swift
@@ -15,6 +15,7 @@ struct JournalDetailBottomSheet: View {
   @EnvironmentObject var journalDetailVM: TravelJournalDetailViewModel
 
   // journal info
+  let journal: TravelJournalDetailData
   let journalId: Int
   let title: String
   let startDate: Date
@@ -33,6 +34,7 @@ struct JournalDetailBottomSheet: View {
   }
 
   init(travelJournal: TravelJournalDetailData) {
+    journal = travelJournal
     journalId = travelJournal.journalId
     title = travelJournal.title
     startDate = travelJournal.travelStartDate
@@ -76,7 +78,7 @@ struct JournalDetailBottomSheet: View {
                 }
               }.frame(width: 50)
 
-              DailyJournalView(journalId: journalId, dailyJournal: dailyJournal)
+              DailyJournalView(journal: journal, dailyJournal: dailyJournal)
             }
           }
           Spacer()

--- a/Odya-iOS/Core/TravelJournal/TravelJournalDetail/View/TravelJournalDetailView.swift
+++ b/Odya-iOS/Core/TravelJournal/TravelJournalDetail/View/TravelJournalDetailView.swift
@@ -23,12 +23,12 @@ struct TravelJournalDetailView: View {
     }
     return journal.isBookmarked
   }
-  
+
   init(journalId: Int, nickname: String = "") {
     self.journalId = journalId
     self.writerNickname = (MyData().nickname == nickname) ? "" : nickname
   }
-  
+
   /// 메뉴 버튼 클릭 시에 메뉴 화면 표시 여부
   @State private var isShowingMeatballMenu: Bool = false
 
@@ -42,15 +42,15 @@ struct TravelJournalDetailView: View {
   @State private var failureMessage: String = ""
 
   // MARK: Body
-  
+
   var body: some View {
-    ZStack() {
+    ZStack {
       GeometryReader { geometry in
         // TODO: map
         Color.odya.elevation.elev4
           .ignoresSafeArea()
 
-          headerBar
+        headerBar
 
         if let journalDetail = journalDetailVM.journalDetail {
           JournalDetailBottomSheet(travelJournal: journalDetail)
@@ -78,7 +78,7 @@ struct TravelJournalDetailView: View {
                 }
             )
         } else {
-            ProgressView()
+          ProgressView()
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
 

--- a/Odya-iOS/Core/TravelJournal/TravelJournalDetail/View/TravelJournalDetailView.swift
+++ b/Odya-iOS/Core/TravelJournal/TravelJournalDetail/View/TravelJournalDetailView.swift
@@ -146,6 +146,7 @@ struct TravelJournalDetailView: View {
           if bottomSheetVM.isSheetOn {
             IconButton("direction-left") {
               withAnimation {
+                bottomSheetVM.scrollToTop = true
                 bottomSheetVM.sheetOffset = 0
                 bottomSheetVM.isSheetOn = false
               }
@@ -170,7 +171,6 @@ struct TravelJournalDetailView: View {
       Spacer()
     }
   }
-
 }
 
 struct TravelJournalDetailView_Previews: PreviewProvider {

--- a/Odya-iOS/Core/TravelJournal/TravelJournalDetail/View/TravelMatesView.swift
+++ b/Odya-iOS/Core/TravelJournal/TravelJournalDetail/View/TravelMatesView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 // MARK: Travel Mates View
 struct TravelMatesView: View {
   let mates: [TravelMate]
-  
+
   var body: some View {
     VStack(spacing: 0) {
       HStack {
@@ -20,14 +20,17 @@ struct TravelMatesView: View {
           .padding(.vertical, 26)
         Spacer()
       }
-      
+
       ScrollView(.vertical, showsIndicators: false) {
         VStack(spacing: 16) {
           ForEach(mates) { mate in
             if let userId = mate.userId,
-               let nickname = mate.nickname,
-               let profileUrl = mate.profileUrl {
-              UserIdentityRowWithFollowing(userId: userId, nickname: nickname, profileUrl: profileUrl, isFollowing: mate.isFollowing)
+              let nickname = mate.nickname,
+              let profileUrl = mate.profileUrl
+            {
+              UserIdentityRowWithFollowing(
+                userId: userId, nickname: nickname, profileUrl: profileUrl,
+                isFollowing: mate.isFollowing)
             }
           }
         }
@@ -44,11 +47,16 @@ struct TravelMatesView_Previews: PreviewProvider {
   static var previews: some View {
     TravelMatesView(
       mates: [
-        TravelMate(userId: 1, nickname: "홍길동aa1", profileUrl: "", isRegistered: true, isFollowing: true),
-        TravelMate(userId: 2, nickname: "홍길동aa2", profileUrl: "", isRegistered: true, isFollowing: true),
-        TravelMate(userId: 3, nickname: "홍길동aa3", profileUrl: "", isRegistered: true, isFollowing: true),
-        TravelMate(userId: 4, nickname: "홍길동aa4", profileUrl: "", isRegistered: true, isFollowing: true),
-        TravelMate(userId: 5, nickname: "홍길동aa5", profileUrl: "", isRegistered: true, isFollowing: true),
+        TravelMate(
+          userId: 1, nickname: "홍길동aa1", profileUrl: "", isRegistered: true, isFollowing: true),
+        TravelMate(
+          userId: 2, nickname: "홍길동aa2", profileUrl: "", isRegistered: true, isFollowing: true),
+        TravelMate(
+          userId: 3, nickname: "홍길동aa3", profileUrl: "", isRegistered: true, isFollowing: true),
+        TravelMate(
+          userId: 4, nickname: "홍길동aa4", profileUrl: "", isRegistered: true, isFollowing: true),
+        TravelMate(
+          userId: 5, nickname: "홍길동aa5", profileUrl: "", isRegistered: true, isFollowing: true),
       ]
     )
 

--- a/Odya-iOS/Core/TravelJournal/TravelJournalDetail/ViewModel/BottomSheetViewModel.swift
+++ b/Odya-iOS/Core/TravelJournal/TravelJournalDetail/ViewModel/BottomSheetViewModel.swift
@@ -12,6 +12,7 @@ class BottomSheetViewModel: ObservableObject {
   @Published var isSheetOn: Bool = false
   @Published var sheetOffset: CGFloat = .zero
   @Published var isScrollAtTop: Bool = false
+  @Published var scrollToTop: Bool = false
 
   let minHeight: CGFloat = UIScreen.main.bounds.height / 5 * 3
   let maxHeight: CGFloat = 60
@@ -41,5 +42,4 @@ class BottomSheetViewModel: ObservableObject {
       self.isSheetOn = false
     }
   }
-
 }

--- a/Odya-iOS/Core/TravelJournal/TravelJournalEdit/View/ContentEditView.swift
+++ b/Odya-iOS/Core/TravelJournal/TravelJournalEdit/View/ContentEditView.swift
@@ -12,19 +12,19 @@ import SwiftUI
 /// 사진, 날짜, 텍스트내용, 위치 수정 가능
 struct ContentEditView: View {
   @EnvironmentObject var journalEditVM: DailyJournalEditViewModel
-  
+
   /// 갤러리 접근 권한
   @State private var imageAccessStatus: PHAuthorizationStatus = .authorized
 
   /// 갤러리 접근 권한이 거부되었을 때 알림 표시 여부
   @State private var isShowingImagesPermissionDeniedAlert = false
-    
+
   /// 데일리 일정 날짜 선택 뷰가 화면에 표시되고 있는지 여부
   @Binding var isDatePickerVisible: Bool
-  
+
   /// 이미지 피커가 현재 화면에 표시되고 있는지 여부
   @Binding var isShowingImagePickerSheet: Bool
-    
+
   /// 텍스트내용 글자 제한 200자
   private let contentCharacterLimit = 200
 
@@ -36,14 +36,13 @@ struct ContentEditView: View {
   @Binding var longitudes: [Double]
   @Binding var fetchedImages: [DailyJournalImage]
   @Binding var selectedImages: [ImageData]
-  
-  
+
   // MARK: Body
-    
+
   var body: some View {
     VStack(spacing: 0) {
       selectedImageList
-      
+
       VStack(spacing: 16) {
         selectedDate
         journalConent
@@ -56,108 +55,108 @@ struct ContentEditView: View {
   private var selectedImageList: some View {
     ScrollView(.horizontal) {
       HStack(spacing: 10) {
-          if fetchedImages.count + selectedImages.count < 15 {
-              imageAddButton
+        if fetchedImages.count + selectedImages.count < 15 {
+          imageAddButton
+        }
+
+        ForEach(selectedImages) { imageData in
+          Button(action: {
+            selectedImages = selectedImages.filter {
+              $0.assetIdentifier != imageData.assetIdentifier
+            }
+          }) {
+            ZStack {
+              Image(uiImage: imageData.image)
+                .resizable()
+                .scaledToFill()
+                .frame(width: 120, height: 120)
+                .cornerRadius(Radius.small)
+              Image("smallGreyButton-x-filled")
+                .offset(x: 55, y: -57.5)
+                .frame(width: 0, height: 0)
+            }
           }
-          
-          ForEach(selectedImages) { imageData in
-              Button(action: {
-                  selectedImages = selectedImages.filter {
-                      $0.assetIdentifier != imageData.assetIdentifier
-                  }
-              }) {
-                  ZStack {
-                      Image(uiImage: imageData.image)
-                          .resizable()
-                          .scaledToFill()
-                          .frame(width: 120, height: 120)
-                          .cornerRadius(Radius.small)
-                      Image("smallGreyButton-x-filled")
-                          .offset(x: 55, y: -57.5)
-                          .frame(width: 0, height: 0)
-                  }
+        }
+
+        ForEach(fetchedImages) { imageData in
+          Button(action: {
+            fetchedImages = fetchedImages.filter {
+              $0.id != imageData.id
+            }
+          }) {
+            ZStack {
+              AsyncImage(url: URL(string: imageData.imageUrl)!) { image in
+                image
+                  .resizable()
+                  .scaledToFill()
+                  .frame(width: 120, height: 120)
+                  .cornerRadius(Radius.small)
+              } placeholder: {
+                ProgressView()
+                  .frame(height: 120)
               }
+              Image("smallGreyButton-x-filled")
+                .offset(x: 55, y: -57.5)
+                .frame(width: 0, height: 0)
+            }
           }
-          
-          ForEach(fetchedImages) { imageData in
-              Button(action: {
-                  fetchedImages = fetchedImages.filter {
-                      $0.id != imageData.id
-                  }
-              }) {
-                  ZStack {
-                      AsyncImage(url: URL(string: imageData.imageUrl)!) { image in
-                          image
-                              .resizable()
-                              .scaledToFill()
-                              .frame(width: 120, height: 120)
-                              .cornerRadius(Radius.small)
-                      } placeholder: {
-                          ProgressView()
-                              .frame(height: 120)
-                      }
-                      Image("smallGreyButton-x-filled")
-                          .offset(x: 55, y: -57.5)
-                          .frame(width: 0, height: 0)
-                  }
-              }
-          }
+        }
         Spacer()
       }.padding(.vertical, 16)
-            .animation(.easeInOut, value: selectedImages)
-            .animation(.easeInOut, value: fetchedImages)
+        .animation(.easeInOut, value: selectedImages)
+        .animation(.easeInOut, value: fetchedImages)
     }
   }
-    
-    /// 이미지 추가 버튼
-    /// 선택된 사진이 15장 미만일 때 나타남
-    private var imageAddButton: some View {
-        Button(action: {
-            let requiredAccessLevel: PHAccessLevel = .readWrite
-            PHPhotoLibrary.requestAuthorization(for: requiredAccessLevel) { authorizationStatus in
-                imageAccessStatus = authorizationStatus
-                switch authorizationStatus {
-                case .authorized, .limited:
-                    isShowingImagePickerSheet = true
-                case .denied, .restricted:
-                    // 권한이 거부된 경우 앱 설정으로 이동 제안
-                    isShowingImagesPermissionDeniedAlert = true
-                default:
-                    break
-                }
-            }
-        }) {
-            Rectangle()
-                .foregroundColor(.clear)
-                .frame(width: 120, height: 120)
-                .background(Color.odya.elevation.elev5)
-                .cornerRadius(Radius.small)
-                .overlay(
-                    VStack(spacing: 0) {
-                        Image("camera")
-                        Text("\(fetchedImages.count + selectedImages.count)/15")
-                            .detail2Style()
-                            .foregroundColor(.odya.label.assistive)
-                    }
-                )
+
+  /// 이미지 추가 버튼
+  /// 선택된 사진이 15장 미만일 때 나타남
+  private var imageAddButton: some View {
+    Button(action: {
+      let requiredAccessLevel: PHAccessLevel = .readWrite
+      PHPhotoLibrary.requestAuthorization(for: requiredAccessLevel) { authorizationStatus in
+        imageAccessStatus = authorizationStatus
+        switch authorizationStatus {
+        case .authorized, .limited:
+          isShowingImagePickerSheet = true
+        case .denied, .restricted:
+          // 권한이 거부된 경우 앱 설정으로 이동 제안
+          isShowingImagesPermissionDeniedAlert = true
+        default:
+          break
         }
-        .alert("사진 액세스 권한 거부", isPresented: $isShowingImagesPermissionDeniedAlert) {
-            HStack {
-                Button("취소") {
-                    isShowingImagesPermissionDeniedAlert = false
-                }
-                Button("설정으로 이동") {
-                    isShowingImagesPermissionDeniedAlert = false
-                    if let settingsURL = URL(string: UIApplication.openSettingsURLString) {
-                        UIApplication.shared.open(settingsURL, options: [:], completionHandler: nil)
-                    }
-                }
-            }
-        } message: {
-            Text("사진 액세스 권한이 거부되었습니다. 설정 앱으로 이동하여 권한을 다시 설정하십시오.")
-        }
-        
+      }
+    }) {
+      Rectangle()
+        .foregroundColor(.clear)
+        .frame(width: 120, height: 120)
+        .background(Color.odya.elevation.elev5)
+        .cornerRadius(Radius.small)
+        .overlay(
+          VStack(spacing: 0) {
+            Image("camera")
+            Text("\(fetchedImages.count + selectedImages.count)/15")
+              .detail2Style()
+              .foregroundColor(.odya.label.assistive)
+          }
+        )
     }
+    .alert("사진 액세스 권한 거부", isPresented: $isShowingImagesPermissionDeniedAlert) {
+      HStack {
+        Button("취소") {
+          isShowingImagesPermissionDeniedAlert = false
+        }
+        Button("설정으로 이동") {
+          isShowingImagesPermissionDeniedAlert = false
+          if let settingsURL = URL(string: UIApplication.openSettingsURLString) {
+            UIApplication.shared.open(settingsURL, options: [:], completionHandler: nil)
+          }
+        }
+      }
+    } message: {
+      Text("사진 액세스 권한이 거부되었습니다. 설정 앱으로 이동하여 권한을 다시 설정하십시오.")
+    }
+
+  }
 
   // MARK: Selected Date
   private var selectedDate: some View {
@@ -213,7 +212,7 @@ struct ContentEditView: View {
     )
     .onChange(of: content) { newValue in
       if newValue.count > contentCharacterLimit {
-          content = String(newValue.prefix(contentCharacterLimit))
+        content = String(newValue.prefix(contentCharacterLimit))
       }
     }
   }
@@ -256,4 +255,3 @@ struct ContentEditView: View {
 //    //        DailyJournalContentEditView(index: 1, dailyJournal: .constant(DailyTravelJournal()), isDatePickerVisible: .constant(false))
 //  }
 //}
-

--- a/Odya-iOS/Core/TravelJournal/TravelJournalEdit/View/DailyJournalEditView.swift
+++ b/Odya-iOS/Core/TravelJournal/TravelJournalEdit/View/DailyJournalEditView.swift
@@ -13,7 +13,7 @@ struct DailyJournalEditView: View {
 
   // MARK: Properties
   @Environment(\.dismiss) var dismiss
-  
+
   @EnvironmentObject var journalDetailVM: TravelJournalDetailViewModel
   @ObservedObject var journalEditVM: DailyJournalEditViewModel
 
@@ -102,7 +102,7 @@ struct DailyJournalEditView: View {
         }.padding(.leading, 8)
         Spacer()
         Button(action: {
-//          journalDetailVM.editedDailyJournal = nil
+          //          journalDetailVM.editedDailyJournal = nil
           Task {
             await journalEditVM.updateDailyJournal(
               date: date, content: content, placeId: placeId, latitudes: latitudes,

--- a/Odya-iOS/Core/TravelJournal/TravelJournalEdit/View/DailyJournalEditView.swift
+++ b/Odya-iOS/Core/TravelJournal/TravelJournalEdit/View/DailyJournalEditView.swift
@@ -12,6 +12,8 @@ import SwiftUI
 struct DailyJournalEditView: View {
 
   // MARK: Properties
+  @Environment(\.dismiss) var dismiss
+  
   @EnvironmentObject var journalDetailVM: TravelJournalDetailViewModel
   @ObservedObject var journalEditVM: DailyJournalEditViewModel
 
@@ -82,6 +84,7 @@ struct DailyJournalEditView: View {
     .confirmationDialog("", isPresented: $isDismissAlertVisible) {
       Button("작성취소", role: .destructive) {
         journalDetailVM.editedDailyJournal = nil
+        dismiss()
       }
       Button("취소", role: .cancel) {}
     } message: {
@@ -99,12 +102,13 @@ struct DailyJournalEditView: View {
         }.padding(.leading, 8)
         Spacer()
         Button(action: {
-          journalDetailVM.editedDailyJournal = nil
+//          journalDetailVM.editedDailyJournal = nil
           Task {
             await journalEditVM.updateDailyJournal(
               date: date, content: content, placeId: placeId, latitudes: latitudes,
               longitudes: longitudes, fetchedImages: fetchedImages, selectedImages: selectedImages)
           }
+          dismiss()
         }) {
           Text("수정 완료")
             .b1Style()


### PR DESCRIPTION
### 개요
- 내 추억 뷰 무한스크롤, 리프레쉬 적용
- 여행일지 디테일 뷰 바텀시트 닫을 때 맨 위로 자동 스크롤
- 여행일지 작성, 수정 뷰 풀스크린으로 열기

### 변경사항
- 개요와 동일
- 내추억 뷰 리펙토링

### 관련 지라 및 위키 링크
- [ODYA-226](https://weit.atlassian.net/browse/ODYA-226)

### 리뷰어에게 하고 싶은 말
- 내 추억뷰 초반에 로딩이 너무 오래되는 것 같아서 progressView 뺴고 바로 뷰 나오게 했습니다! 대신 api로 내 여행일지 가져오는 동안에 메인 랜덤 여행일지를 '오댜 로고 이미지'가 뜨게 했어요(디자인시스템에 있는 시스템 오류로 이미지 안보일 때). 여기서 약간의 문제가 있다면 여행일지 없을 경우 나오는 뷰가 일시적으로 떴다가 사라지는 건데.. 요거는 어떻게 처리할 지 고민해보겠습니다...