### PR TITLE
FEAT: 타인의 친구관리 뷰 수정

### DIFF
--- a/Odya-iOS/Components/UserIdentityLink.swift
+++ b/Odya-iOS/Components/UserIdentityLink.swift
@@ -89,7 +89,7 @@ struct UserIdentityRowWithFollowing: View {
     self.userId = followUser.userId
     self.nickname = followUser.nickname
     self.profileUrl = followUser.profile.profileUrl
-    self.isFollowing = true
+    self.isFollowing = followUser.isFollowing
   }
   
   // Writer

--- a/Odya-iOS/Core/Follow/FollowButtonViewModel.swift
+++ b/Odya-iOS/Core/Follow/FollowButtonViewModel.swift
@@ -27,7 +27,7 @@ class FollowButtonViewModel: ObservableObject {
   
   /// 팔로우 실행
   func createFollow(_ followingID: Int) {
-    followProvider.requestPublisher(.create(followingID: followingID))
+    followProvider.requestPublisher(.create(followingId: followingID))
       .sink { completion in
         switch completion {
         case .finished:
@@ -44,7 +44,7 @@ class FollowButtonViewModel: ObservableObject {
   
   /// 언팔로우 실행
   func deleteFollow(_ followingID: Int) {
-    followProvider.requestPublisher(.delete(followingID: followingID))
+    followProvider.requestPublisher(.delete(followingId: followingID))
       .sink { completion in
         switch completion {
         case .finished:

--- a/Odya-iOS/Core/Follow/FollowHubViewModel.swift
+++ b/Odya-iOS/Core/Follow/FollowHubViewModel.swift
@@ -106,6 +106,11 @@ class FollowHubViewModel: ObservableObject {
     followerUsers = []
   }
   
+  func initSearchData() {
+    initFollowingData()
+    initFollowerData()
+  }
+  
   // MARK: Fetch Follow Users
   
   /// 팔로잉 유저, 팔로워 유저 리스트 첫 번째 페이지를 받아옴
@@ -296,8 +301,7 @@ class FollowHubViewModel: ObservableObject {
   /// 닉네임으로 팔로워/팔로잉 유저 검색
   func searchFollowUsers(
     by nickname: String,
-    userId: Int,
-    completion: @escaping (Bool) -> Void
+    userId: Int
   ) {
     followingSearchResult = []
     followerSearchResult = []
@@ -311,11 +315,7 @@ class FollowHubViewModel: ObservableObject {
     
     searchFollowingUsers(by: nickname, userId: userId) { success in
       if success {
-        self.searchFollowerUsers(by: nickname, userId: userId) { success in
-          if success {
-            completion(true)
-          }
-        }
+        self.searchFollowerUsers(by: nickname, userId: userId) { _ in }
       }
     }
   }

--- a/Odya-iOS/Core/Follow/FollowHubViewModel.swift
+++ b/Odya-iOS/Core/Follow/FollowHubViewModel.swift
@@ -105,65 +105,6 @@ class FollowHubViewModel: ObservableObject {
     }.store(in: &subscription)
   }
 
-  // MARK: follow / unfollow
-
-  /// 팔로우 실행
-  func createFollow(_ followingID: Int) {
-    guard self.idToken != nil else {
-      return
-    }
-    
-    if isCreatingFollow {
-      return
-    }
-    
-    isCreatingFollow = true
-    followProvider.requestPublisher(.create(followingID: followingID))
-      .filterSuccessfulStatusCodes()
-      .sink { completion in
-        switch completion {
-        case .finished:
-          self.isCreatingFollow = false
-          // print("create new follow \(followingID)")
-        case .failure(let error):
-          self.isCreatingFollow = false
-          if let errorData = try? error.response?.map(ErrorData.self) {
-            print(errorData.message)
-          }
-        }
-      } receiveValue: { _ in
-      }
-      .store(in: &subscription)
-  }
-
-  /// 언팔로우 실행
-  func deleteFollow(_ followingID: Int) {
-    guard self.idToken != nil else {
-      return
-    }
-    
-    
-    if isDeletingFollow {
-      return
-    }
-    
-    isDeletingFollow = true
-    followProvider.requestPublisher(.delete(followingID: followingID))
-      .sink { completion in
-        switch completion {
-        case .finished:
-          self.isDeletingFollow = false
-          // print("delete follow \(followingID)")
-        case .failure(let error):
-          self.isDeletingFollow = false
-          if let errorData = try? error.response?.map(ErrorData.self) {
-            print(errorData.message)
-          }
-        }
-      } receiveValue: { _ in
-      }
-      .store(in: &subscription)
-  }
 
   // MARK: Fetch Follow Users
 

--- a/Odya-iOS/Core/Follow/FollowHubViewModel.swift
+++ b/Odya-iOS/Core/Follow/FollowHubViewModel.swift
@@ -12,283 +12,274 @@ import Foundation
 import Moya
 
 class FollowHubViewModel: ObservableObject {
-
+  
   // MARK: Parameters
-
+  
   // moya
+  @AppStorage("WeITAuthToken") var idToken: String?
   private let logPlugin: PluginType = NetworkLoggerPlugin(
     configuration: .init(logOptions: .verbose))
   private lazy var authPlugin = AccessTokenPlugin { [self] _ in idToken ?? "" }
   private lazy var followProvider = MoyaProvider<FollowRouter>(
     session: Session(interceptor: AuthInterceptor.shared), plugins: [logPlugin, authPlugin])
   private var subscription = Set<AnyCancellable>()
-
+  
   // infinite scroll
-  var fetchMoreSubject = PassthroughSubject<(), Never>()
+  var fetchMoreSubject = PassthroughSubject<(Int), Never>()
   var suggestMoreSubject = PassthroughSubject<(), Never>()
-
+  
   // user info required for API calls
-  @Published var appDataManager = AppDataManager()
-  @AppStorage("WeITAuthToken") var idToken: String?
-  var userID: Int
-
+  //  var userID: Int
   @Published var currentFollowType: FollowType
-
-  // follow/ unfollow
-  var isCreatingFollow: Bool = false
-  var isDeletingFollow: Bool = false
   
   // fetch following/follwer users
   @Published var isLoading: Bool = false
   @Published var isRefreshing: Bool = false
-
+  
   var followingPage: Int = 0
   var hasNextFollowingPage: Bool = true
   @Published var followingUsers: [FollowUserData] = []
-
+  
   var followerPage: Int = 0
   var hasNextFollowerPage: Bool = true
   @Published var followerUsers: [FollowUserData] = []
-
+  
   // suggest user
   @Published var isLoadingSuggestion: Bool = false
-
+  
   var lastIdOfSuggestion: Int? = nil
   var hasNextSuggestion: Bool = true
   @Published var suggestedUsers: [FollowUserData] = []
-
+  
   // search by name
   @Published var isLoadingSearchResult: Bool = false
   @Published var followingSearchResult: [FollowUserData] = []
   @Published var followerSearchResult: [FollowUserData] = []
-
-  /*/ 닉네임 검색 api 사용 시 필요
-    var searchMoreSubject = PassthroughSubject<(String), Never>() // 무한스크롤 적용
-
-    var lastIdOfFollowingSearchResult: Int? = nil
-    var hasNextFollowingSearchResult: Bool = true
-
-    var lastIdOfFollowerSearchResult: Int? = nil
-    var hasNextFollowerSearchResult: Bool = true
-     */
-
+  
+  /* 닉네임 검색 api 사용 시 필요
+   var searchMoreSubject = PassthroughSubject<(String), Never>() // 무한스크롤 적용
+   
+   var lastIdOfFollowingSearchResult: Int? = nil
+   var hasNextFollowingSearchResult: Bool = true
+   
+   var lastIdOfFollowerSearchResult: Int? = nil
+   var hasNextFollowerSearchResult: Bool = true
+   */
+  
   // MARK: Init
-  init(userId: Int = MyData.userID) {
+  init() {
     self.currentFollowType = .following
-    self.userID = userId
     
-    initInfiniteScroll()
-  }
-  
-  // MARK: Init Infinite Scroll
-  
-  private func initInfiniteScroll() {
     /// 팔로워 / 팔로잉 리스트 무한스크롤
-    fetchMoreSubject.sink { [weak self] _ in
+    fetchMoreSubject.sink { [weak self] userId in
       guard let self = self else { return }
       if !self.isLoading {
         switch currentFollowType {
         case .following:
-          self.fetchFollowingUsers(userId: self.userID) { _ in }
+          self.fetchFollowingUsers(userId: userId) { _ in }
         case .follower:
-          self.fetchFollowerUsers(userId: self.userID) { _ in }
+          self.fetchFollowerUsers(userId: userId) { _ in }
         }
       }
     }.store(in: &subscription)
-
+    
     /// 알 수도 있는 친구 무한스크롤
     suggestMoreSubject.sink { [weak self] _ in
       guard let self = self else { return }
       if !self.isLoadingSuggestion {
-        self.suggestUsers(idToken: idToken ?? "") { _ in }
+        self.fetchSuggestedUsers {}
       }
     }.store(in: &subscription)
   }
-
-
-  // MARK: Fetch Follow Users
-
-  /// 팔로잉 유저 리스트 첫 번째 페이지를 받아옴
-  func initFollowingUsers(completion: @escaping (Bool) -> Void) {
-    guard idToken != nil else {
-       return
-    }
-    
+  
+  /// 팔로잉 리스트 조회에 필요한 데이터들 초기화
+  private func initFollowingData() {
     followingPage = 0
     hasNextFollowingPage = true
     followingUsers = []
-
-    fetchFollowingUsers(userId: self.userID) { _ in
-      completion(true)
-    }
   }
-
-  /// 팔로워 유저 리스트 첫 번째 페이지를 받아옴
-  func initFollowerUsers(completion: @escaping (Bool) -> Void) {
-    guard self.idToken != nil else {
-       return
-    }
-    
+  
+  /// 팔로워 리스트 조회에 필요한 데이터들 초기화
+  private func initFollowerData() {
     followerPage = 0
     hasNextFollowerPage = true
     followerUsers = []
-
-    fetchFollowerUsers(userId: self.userID) { _ in
-      completion(true)
+  }
+  
+  // MARK: Fetch Follow Users
+  
+  /// 팔로잉 유저, 팔로워 유저 리스트 첫 번째 페이지를 받아옴
+  func initFollowingFollower(userId: Int) {
+    initFollowingData()
+    initFollowerData()
+    
+    fetchFollowingUsers(userId: userId) { success in
+      if success {
+        self.fetchFollowerUsers(userId: userId) { _ in }
+      }
     }
   }
-
+  
+  /// 팔로잉 유저, 팔로워 유저 리스트 새로고침
+  /// 현재 보여지는 리스트만 새로고침됨
+  func refreshFollowingFollower(userId: Int) {
+    isRefreshing = true
+    switch currentFollowType {
+    case .following:
+      initFollowingData()
+      fetchFollowingUsers(userId: userId) { _ in }
+    case .follower:
+      initFollowerData()
+      fetchFollowerUsers(userId: userId) { _ in }
+    }
+  }
+  
+  /// 팔로잉 유저 리스트 첫 번째 페이지를 받아옴
+  func initFollowingUsers(userId: Int) {
+    initFollowingData()
+    fetchFollowingUsers(userId: userId) { _ in }
+  }
+  
+  /// 팔로워 유저 리스트 첫 번째 페이지를 받아옴
+  func initFollowerUsers(userId: Int) {
+    followerUsers = []
+    fetchFollowerUsers(userId: userId) { _ in }
+  }
+  
   /// api를 통해 팔로잉 유저 리스트를 받아오는 함수
   /// size: 한 페이지에 포함된 유저 수,  sortType: 정렬방식 (최신순 / 오래된순)
-  private func fetchFollowingUsers(userId: Int,
-                                   size: Int = 20, sortType: FollowSortingType = .latest, completion: @escaping (Bool) -> Void
+  private func fetchFollowingUsers(
+    userId: Int,
+    size: Int = 20,
+    sortType: FollowSortingType = .latest,
+    completion: @escaping (Bool) -> Void
   ) {
-    guard self.idToken != nil else {
-       return
+    
+    // all following users are fetched
+    if hasNextFollowingPage == false {
+      return
     }
     
-    if self.hasNextFollowingPage == false {
-      // print("all following users are fetched")
+    // already fetching
+    if isLoading {
       return
     }
-
-    if self.isLoading {
-      return
-    }
-
+    
     self.isLoading = true
-
     followProvider.requestPublisher(
-      .getFollowing(userID: userId, page: self.followingPage, size: size, sortType: sortType)
+      .getFollowing(userId: userId, page: self.followingPage, size: size, sortType: sortType)
     )
-    .filterSuccessfulStatusCodes()
     .sink { apiCompletion in
       self.isLoading = false
       self.isRefreshing = false
-
+      
       switch apiCompletion {
       case .finished:
         self.followingPage += 1
         // print( "fetch \(self.followingPage)th following users: now \(self.followingUsers.count) users are fetched")
         completion(true)
       case .failure(let error):
-        if let errorData = try? error.response?.map(ErrorData.self) {
-          print(errorData.message)
-        }
+        self.processErrorResponse(error)
       }
     } receiveValue: { response in
       guard let responseData = try? response.map(FollowUserListResponse.self) else {
         return
       }
-
       self.hasNextFollowingPage = responseData.hasNext
       self.followingUsers += responseData.content
     }
     .store(in: &subscription)
   }
-
+  
   /// api를 통해 팔로워 유저 리스트를 받아오는 함수
   /// size: 한 페이지에 포함된 유저 수,  sortType: 정렬방식 (최신순 / 오래된순)
-  private func fetchFollowerUsers(userId: Int, size: Int = 20, sortType: FollowSortingType = .latest, completion: @escaping (Bool) -> Void
+  private func fetchFollowerUsers(
+    userId: Int,
+    size: Int = 20,
+    sortType: FollowSortingType = .latest,
+    completion: @escaping (Bool) -> Void
   ) {
-    guard self.idToken != nil else {
-       return
+    // all follower users are fetched
+    if hasNextFollowerPage == false {
+      return
     }
     
-    if self.hasNextFollowerPage == false {
-      print("all follower users are fetched")
+    // already loading
+    if isLoading {
       return
     }
-
-    if self.isLoading {
-      print("follower users are already loading")
-      return
-    }
-
+    
     self.isLoading = true
-
     followProvider.requestPublisher(
-      .getFollower(userID: self.userID, page: self.followerPage, size: size, sortType: sortType)
+      .getFollower(userId: userId, page: self.followerPage, size: size, sortType: sortType)
     )
-    .filterSuccessfulStatusCodes()
     .sink { apiCompletion in
       self.isLoading = false
       self.isRefreshing = false
-
+      
       switch apiCompletion {
       case .finished:
         self.followerPage += 1
         // print( "fetch \(self.followerPage)th following users: now \(self.followerUsers.count) users are fetched")
         completion(true)
       case .failure(let error):
-        if let errorData = try? error.response?.map(ErrorData.self) {
-          print(errorData.message)
-        }
+        self.processErrorResponse(error)
       }
     } receiveValue: { response in
       guard let responseData = try? response.map(FollowUserListResponse.self) else {
         print("Error: following users response decoding error")
         return
       }
-
+      
       self.hasNextFollowerPage = responseData.hasNext
       self.followerUsers += responseData.content
     }
     .store(in: &subscription)
   }
-
+  
   // MARK: Suggest User
-
+  
   /// 알 수도 있는 친구 추천 리스트 첫 번째 페이지를 받아옴
   func getSuggestion(completion: @escaping (Bool) -> Void) {
-    guard let idToken = self.idToken else {
-       return
-    }
-    
     self.lastIdOfSuggestion = nil
     self.hasNextSuggestion = true
     self.suggestedUsers = []
-
-    suggestUsers(idToken: idToken) { _ in
+    
+    fetchSuggestedUsers() {
       completion(true)
     }
   }
-
+  
   /// api를 통해 알 수도 있는 친구 추천 리스트를 받아오는 함수
   /// size: 한 페이지에 포함된 유저 수
-  private func suggestUsers(
-    idToken: String,
+  private func fetchSuggestedUsers(
     size: Int = 10,
-    completion: @escaping (Bool) -> Void
+    completion: @escaping () -> Void
   ) {
+    // no more suggestion
     if self.hasNextSuggestion == false {
-      print("no more suggestion")
       return
     }
-
+    
     self.isLoadingSuggestion = true
-
     followProvider.requestPublisher(
-      .suggestUser(size: size, lastID: self.lastIdOfSuggestion)
+      .suggestUser(size: size, lastId: self.lastIdOfSuggestion)
     )
-    .filterSuccessfulStatusCodes()
     .sink { apiCompletion in
       switch apiCompletion {
       case .finished:
         self.isLoadingSuggestion = false
         // print("suggest total \(self.suggestedUsers.count) users")
-        completion(true)
+        completion()
       case .failure(let error):
-        if let errorData = try? error.response?.map(ErrorData.self) {
-          print(errorData.message)
-        }
+        self.processErrorResponse(error)
       }
     } receiveValue: { response in
       guard let responseData = try? response.map(FollowUserListResponse.self) else {
         // print("Error: following users response decoding error")
         return
       }
-
+      
       self.hasNextSuggestion = responseData.hasNext
       self.suggestedUsers += responseData.content
       if let lastUser = self.suggestedUsers.last {
@@ -299,20 +290,28 @@ class FollowHubViewModel: ObservableObject {
     }
     .store(in: &subscription)
   }
-
+  
   // MARK: Search Users By Nickname
-
+  
   /// 닉네임으로 팔로워/팔로잉 유저 검색
   func searchFollowUsers(
     by nickname: String,
+    userId: Int,
     completion: @escaping (Bool) -> Void
   ) {
     followingSearchResult = []
     followerSearchResult = []
-
-    searchFollowingUsers(by: nickname) { success in
+    
+    /*
+    lastIdOfFollowingSearchResult = nil
+    hasNextFollowingSearchResult = true
+    lastIdOfFollowerSearchResult = nil
+    hasNextFollowerSearchResult = true
+     */
+    
+    searchFollowingUsers(by: nickname, userId: userId) { success in
       if success {
-        self.searchFollowerUsers(by: nickname) { success in
+        self.searchFollowerUsers(by: nickname, userId: userId) { success in
           if success {
             completion(true)
           }
@@ -320,82 +319,91 @@ class FollowHubViewModel: ObservableObject {
       }
     }
   }
-
+  
   /// 닉네임으로 팔로잉 유저 검색
-  func searchFollowingUsers(by nickname: String, completion: @escaping (Bool) -> Void) {
-    guard let idToken = self.idToken else {
-       return
-    }
-    
+  func searchFollowingUsers(by nickname: String,
+                            userId: Int,
+                            completion: @escaping (Bool) -> Void) {
     isLoadingSearchResult = true
-
+    
     if hasNextFollowingPage {
-      fetchAllFollowingUsers(idToken: idToken, userId: self.userID) { [self] allUsers in
+      // TODO: 팔로잉 수가 많을 경우 검색 api 사용
+      
+      // 팔로잉 수가 많지 않을 경우 fetchAll로 가져온 데이터에서 검색
+      fetchAllFollowingUsers(userId: userId) { [self] allUsers in
         followingSearchResult = allUsers.filter {
           $0.nickname.localizedCaseInsensitiveContains(nickname)
         }
         isLoadingSearchResult = false
         completion(true)
       }
-    } else {
+    }
+    
+    // 이미 팔로잉 리스트를 모두 가져온 상태인 경우
+    else {
       followingSearchResult = followingUsers.filter {
         $0.nickname.localizedCaseInsensitiveContains(nickname)
       }
       isLoadingSearchResult = false
       completion(true)
     }
-
-    /*
-        fetchSearchedFollowings(by: nickname, result: searchedUsers) { result in
-            followingResult = result
-        }
-        */
-  }
-
-  /// 닉네임으로 팔로워 유저 검색
-  private func searchFollowerUsers(by nickname: String, completion: @escaping (Bool) -> Void) {
-    guard let idToken = self.idToken else {
-       return
-    }
     
+    /*
+     fetchSearchedFollowings(by: nickname, result: searchedUsers) { result in
+     followingResult = result
+     }
+     */
+  }
+  
+  /// 닉네임으로 팔로워 유저 검색
+  private func searchFollowerUsers(by nickname: String,
+                                   userId: Int,
+                                   completion: @escaping (Bool) -> Void) {
     isLoadingSearchResult = true
-
+    
     if hasNextFollowerPage {
-      fetchAllFollowerUsers(idToken: idToken, userId: self.userID) { [self] allUsers in
+      // TODO: 팔로워 수가 많을 경우 검색 api 사용
+      
+      // 팔로워 수가 많지 않을 경우 fetchAll로 가져온 데이터에서 검색
+      fetchAllFollowerUsers(userId: userId) { [self] allUsers in
         followerSearchResult = allUsers.filter { searchedUser in
           searchedUser.nickname.localizedCaseInsensitiveContains(nickname)
-            && followingSearchResult.filter({ $0.userId == searchedUser.userId }).isEmpty
+          && followingSearchResult.filter({ $0.userId == searchedUser.userId }).isEmpty
         }
         isLoadingSearchResult = false
         completion(true)
       }
-    } else {
+    }
+    
+    // 이미 팔로워 리스트를 모두 가져온 상태인 경우
+    else {
       followerSearchResult = followerUsers.filter { searchedUser in
         searchedUser.nickname.localizedCaseInsensitiveContains(nickname)
-          && followingSearchResult.filter({ $0.userId == searchedUser.userId }).isEmpty
+        && followingSearchResult.filter({ $0.userId == searchedUser.userId }).isEmpty
       }
       isLoadingSearchResult = false
       completion(true)
     }
     /*
-        fetchSearchedFollowings(by: nickname, result: searchedUsers) { result in
-            followingResult = result
-        }
-        */
+     fetchSearchedFollowings(by: nickname, result: searchedUsers) { result in
+     followingResult = result
+     }
+     */
   }
-
-  // MARK: fetch All Users
+  
+  // MARK: fetch All Users to Search
   /// 모든 팔로잉 유저를 받아옴
-  private func fetchAllFollowingUsers(idToken: String, userId: Int, completion: @escaping ([FollowUserData]) -> Void) {
+  private func fetchAllFollowingUsers(userId: Int,
+                                      completion: @escaping ([FollowUserData]) -> Void) {
     var allFollowingUsers: [FollowUserData] = []
-
+    
     func fetchNextPage() {
       fetchFollowingUsers(userId: userId, size: 100) { success in
         if success {
           if self.hasNextFollowingPage {
             fetchNextPage()
           } else {
-            print("get all following users")
+            // print("get all following users")
             allFollowingUsers = self.followingUsers
             completion(allFollowingUsers)
           }
@@ -404,14 +412,15 @@ class FollowHubViewModel: ObservableObject {
         }
       }
     }
-
+    
     fetchNextPage()
   }
-
+  
   /// 모든 팔로워 유저를 받아옴
-  private func fetchAllFollowerUsers(idToken: String, userId: Int, completion: @escaping ([FollowUserData]) -> Void) {
+  private func fetchAllFollowerUsers(userId: Int,
+                                     completion: @escaping ([FollowUserData]) -> Void) {
     var allFollowerUsers: [FollowUserData] = []
-
+    
     func fetchNextPage() {
       fetchFollowerUsers(userId: userId, size: 100) { success in
         if success {
@@ -427,92 +436,97 @@ class FollowHubViewModel: ObservableObject {
         }
       }
     }
-
+    
     fetchNextPage()
   }
   
-
+  
   /*
-    private func fetchSearchedFollowings(by nickname: String,
-                                         result: [FollowUserData],
-                                         completion: @escaping ([FollowUserData]) -> Void) {
-        if self.isLoadingSearchResult {
-            return
-        }
-
-        self.isLoadingSearchResult = true
-        var newResult = result
-
-        followProvider.requestPublisher(.searchFollowingByNickname(token: self.idToken, nickname: nickname, lastID: self.lastIdOfFollowingSearchResult))
-            .sink { apiCompletion in
-                switch apiCompletion {
-                case .finished:
-                    self.isLoadingSearchResult = false
-                    completion(newResult)
-                case .failure(let error):
-                    if let errorData = try? error.response?.map(ErrorData.self) {
-                        print(errorData.message)
-                    }
-                }
-            } receiveValue: { response in
-                guard let responseData = try? response.map(FollowUserListResponse.self) else {
-                    print("Error: following users response decoding error")
-                    return
-                }
-
-                self.hasNextFollowingSearchResult = responseData.hasNext
-                for newUser in responseData.content {
-                    if !result.contains(newUser) {
-                        newResult.append(newUser)
-                    }
-                }
-                if let lastUser = responseData.content.last {
-                    self.lastIdOfFollowingSearchResult = lastUser.userId
-                } else {
-                    self.lastIdOfFollowingSearchResult = nil
-                }
-            }.store(in: &subscription)
+  /// api를 이용해 팔로잉 검색
+  private func fetchSearchedFollowings(by nickname: String,
+                                       userId: Int,
+                                       completion: @escaping (Bool) -> Void) {
+    // already fetching
+    if self.isLoadingSearchResult {
+      return
     }
-
-    private func fetchSearcedFollowers(by nickname: String,
-                                       result: [FollowUserData],
-                                       completion: @escaping ([FollowUserData]) -> Void) {
-        if self.isLoadingSearchResult {
-            return
+    
+    self.isLoadingSearchResult = true
+    followProvider.requestPublisher(
+      .searchFollowingByNickname(userId: userId,
+                                 nickname: nickname,
+                                 lastId: lastIdOfFollowingSearchResult))
+      .sink { apiCompletion in
+        self.isLoadingSearchResult = false
+        
+        switch apiCompletion {
+        case .finished:
+          completion(true)
+        case .failure(let error):
+          self.processErrorResponse(error)
         }
-
-        self.isLoadingSearchResult = true
-        var newResult = result
-
-        followProvider.requestPublisher(.searchFollowerByNickname(token: self.idToken, nickname: nickname, lastID: self.lastIdOfFollowerSearchResult))
-            .sink { apiCompletion in
-                switch apiCompletion {
-                case .finished:
-                    self.isLoadingSearchResult = false
-                    completion(newResult)
-                case .failure(let error):
-                    if let errorData = try? error.response?.map(ErrorData.self) {
-                        print(errorData.message)
-                    }
-                }
-            } receiveValue: { response in
-                guard let responseData = try? response.map(FollowUserListResponse.self) else {
-                    print("Error: following users response decoding error")
-                    return
-                }
-
-                self.hasNextFollowerSearchResult = responseData.hasNext
-                for newUser in responseData.content {
-                    if !result.contains(newUser) {
-                        newResult.append(newUser)
-                    }
-                }
-                if let lastUser = responseData.content.last {
-                    self.lastIdOfFollowerSearchResult = lastUser.userId
-                } else {
-                    self.lastIdOfFollowerSearchResult = nil
-                }
-            }.store(in: &subscription)
+      } receiveValue: { response in
+        guard let responseData = try? response.map(FollowUserListResponse.self) else {
+          print("Error: following users response decoding error")
+          return
+        }
+        
+        self.hasNextFollowingSearchResult = responseData.hasNext
+        self.followingSearchResult += responseData.content
+        if let lastUser = responseData.content.last {
+          self.lastIdOfFollowingSearchResult = lastUser.userId
+        } else {
+          self.lastIdOfFollowingSearchResult = nil
+        }
+      }.store(in: &subscription)
+  }
+  
+   /// api를 이용해 팔로워 검색
+  private func fetchSearcedFollowers(by nickname: String,
+                                     userId: Int,
+                                     completion: @escaping (Bool) -> Void) {
+    // already fetching
+    if self.isLoadingSearchResult {
+      return
     }
-     */
+    
+    self.isLoadingSearchResult = true
+    followProvider.requestPublisher(
+      .searchFollowerByNickname(userId: userId,
+                                nickname: nickname,
+                                lastId: self.lastIdOfFollowerSearchResult))
+      .sink { apiCompletion in
+        self.isLoadingSearchResult = false
+        
+        switch apiCompletion {
+        case .finished:
+          completion(true)
+        case .failure(let error):
+          self.processErrorResponse(error)
+        }
+      } receiveValue: { response in
+        guard let responseData = try? response.map(FollowUserListResponse.self) else {
+          print("Error: following users response decoding error")
+          return
+        }
+        
+        self.hasNextFollowerSearchResult = responseData.hasNext
+        self.followerSearchResult += responseData.content
+        if let lastUser = responseData.content.last {
+          self.lastIdOfFollowerSearchResult = lastUser.userId
+        } else {
+          self.lastIdOfFollowerSearchResult = nil
+        }
+      }.store(in: &subscription)
+  }
+  */
+  
+  // MARK: Error Handling
+  private func processErrorResponse(_ error: MoyaError) {
+    if let errorData = try? error.response?.map(ErrorData.self) {
+      print("in follow hub view model - \(errorData.message)")
+    } else {  // unknown error
+      print("in follow hub view model - \(error)")
+    }
+  }
 }

--- a/Odya-iOS/Core/Follow/View/FollowHubView.swift
+++ b/Odya-iOS/Core/Follow/View/FollowHubView.swift
@@ -58,8 +58,20 @@ struct FollowSearchBar: View {
 struct FollowHubView: View {
   @ObservedObject var followHubVM: FollowHubViewModel
   
+  var isMyFollowHub: Bool {
+    followHubVM.userID == MyData.userID
+  }
+  
   /// 화면에 표시되는 리스트 - 팔로워리스트 / 팔로잉리스트 / 검색 결과 리스트
-  @State var displayedUsers: [FollowUserData] = []
+//  @State var displayedUsers: [FollowUserData] = []
+  var displayedUsers: [FollowUserData] {
+    switch followHubVM.currentFollowType {
+    case .following:
+      return followHubVM.followingUsers
+    case .follower:
+      return followHubVM.followerUsers
+    }
+  }
   
   /// 검색하려는 닉네임
   @State var nameToSearch: String = ""
@@ -94,22 +106,21 @@ struct FollowHubView: View {
           .padding(.vertical, 20)
         
         // 리스트
-        FollowUserListView(of: $displayedUsers)
-          .environmentObject(followHubVM)
+        FollowUserListView
           .refreshable {
             followHubVM.isRefreshing = true
             switch followHubVM.currentFollowType {
             case .following:
-              followHubVM.initFollowingUsers { result in
-                if result {
-                  displayedUsers = followHubVM.followingUsers
-                }
+              followHubVM.initFollowingUsers { _ in
+//                if result {
+//                  displayedUsers = followHubVM.followingUsers
+//                }
               }
             case .follower:
-              followHubVM.initFollowerUsers { result in
-                if result {
-                  displayedUsers = followHubVM.followerUsers
-                }
+              followHubVM.initFollowerUsers { _ in
+//                if result {
+//                  displayedUsers = followHubVM.followerUsers
+//                }
               }
             }
           }
@@ -127,20 +138,20 @@ struct FollowHubView: View {
     .onAppear {
       followHubVM.initFollowingUsers { success in
         followHubVM.initFollowerUsers { _ in }
-        if success {
-          displayedUsers = followHubVM.followingUsers
-        }
+//        if success {
+//          displayedUsers = followHubVM.followingUsers
+//        }
       }
     }
     .onDisappear {
       followHubVM.currentFollowType = .following
       nameToSearch = ""
     }
-    .onChange(of: followHubVM.currentFollowType) { newValue in
-      displayedUsers =
-        newValue == .following
-        ? followHubVM.followingUsers : followHubVM.followerUsers
-    }
+//    .onChange(of: followHubVM.currentFollowType) { newValue in
+//      displayedUsers =
+//        newValue == .following
+//        ? followHubVM.followingUsers : followHubVM.followerUsers
+//    }
   }
 
   // MARK: Follow Type Toggle

--- a/Odya-iOS/Core/Follow/View/FollowUserListView.swift
+++ b/Odya-iOS/Core/Follow/View/FollowUserListView.swift
@@ -92,14 +92,13 @@ struct SearchedUserListView: View {
   let userId: Int
   let nameToSearch: String
   
-  @State var searchedFollowingUser: [FollowUserData] = []
-  @State var searchedFollowerUser: [FollowUserData] = []
-  
   var body: some View {
     ScrollView {
       VStack(spacing: 16) {
-        showList(of: searchedFollowingUser, followType: .following)
-        showList(of: searchedFollowerUser, followType: .follower)
+        showList(of: followHubVM.followingSearchResult,
+                 showDeletionButton: false)
+        showList(of: followHubVM.followerSearchResult,
+                 showDeletionButton: userId == MyData.userID)
         
         // 검색 결과를 로딩할 때 나오는 로딩 뷰
         if followHubVM.isLoadingSearchResult {
@@ -110,41 +109,24 @@ struct SearchedUserListView: View {
       }.padding(.horizontal, GridLayout.side)
     }
     .onAppear {
-      followHubVM.searchFollowUsers(by: nameToSearch, userId: userId) { success in
-        if success {
-          searchedFollowingUser = followHubVM.followingSearchResult
-          searchedFollowerUser = followHubVM.followerSearchResult
-        }
-      }
+      followHubVM.searchFollowUsers(by: nameToSearch, userId: userId)
     }
     .onChange(of: nameToSearch) { newValue in
-      followHubVM.searchFollowUsers(by: newValue, userId: userId) { success in
-        if success {
-          searchedFollowingUser = followHubVM.followingSearchResult
-          searchedFollowerUser = followHubVM.followerSearchResult
-        }
-      }
+      followHubVM.searchFollowUsers(by: newValue, userId: userId)
     }
     .refreshable {
-      followHubVM.searchFollowUsers(by: nameToSearch, userId: userId) { success in
-        if success {
-          searchedFollowingUser = followHubVM.followingSearchResult
-          searchedFollowerUser = followHubVM.followerSearchResult
-        }
-      }
+      followHubVM.initSearchData()
+      followHubVM.searchFollowUsers(by: nameToSearch, userId: userId)
     }
   }
 
 
-  private func showList(of users: [FollowUserData], followType: FollowType) -> some View {
+  private func showList(of users: [FollowUserData], showDeletionButton: Bool) -> some View {
     ForEach(users) { user in
-      switch followType {
-      case .following:
-        UserIdentityRowWithFollowing(of: user)
-          .environmentObject(followHubVM)
-      case .follower:
+      if showDeletionButton {
         FollowerUserRowView(of: user)
-          .environmentObject(followHubVM)
+      } else {
+        UserIdentityRowWithFollowing(of: user)
       }
     }
   }

--- a/Odya-iOS/Core/Follow/View/FollowUserListView.swift
+++ b/Odya-iOS/Core/Follow/View/FollowUserListView.swift
@@ -53,7 +53,7 @@ extension FollowHubView {
       .padding(.horizontal, GridLayout.side)
       .onAppear {
         if users.last == user {
-          followHubVM.fetchMoreSubject.send()
+          followHubVM.fetchMoreSubject.send(userId)
         }
       }
 
@@ -88,17 +88,19 @@ extension FollowHubView {
 ///  닉네임으로 검색된 팔로워/팔로잉 결과 리스트를 보여주는 뷰
 struct SearchedUserListView: View {
   @EnvironmentObject var followHubVM: FollowHubViewModel
-
+  
+  let userId: Int
   let nameToSearch: String
+  
   @State var searchedFollowingUser: [FollowUserData] = []
   @State var searchedFollowerUser: [FollowUserData] = []
-
+  
   var body: some View {
     ScrollView {
       VStack(spacing: 16) {
         showList(of: searchedFollowingUser, followType: .following)
         showList(of: searchedFollowerUser, followType: .follower)
-
+        
         // 검색 결과를 로딩할 때 나오는 로딩 뷰
         if followHubVM.isLoadingSearchResult {
           Spacer()
@@ -108,7 +110,7 @@ struct SearchedUserListView: View {
       }.padding(.horizontal, GridLayout.side)
     }
     .onAppear {
-      followHubVM.searchFollowUsers(by: nameToSearch) { success in
+      followHubVM.searchFollowUsers(by: nameToSearch, userId: userId) { success in
         if success {
           searchedFollowingUser = followHubVM.followingSearchResult
           searchedFollowerUser = followHubVM.followerSearchResult
@@ -116,7 +118,7 @@ struct SearchedUserListView: View {
       }
     }
     .onChange(of: nameToSearch) { newValue in
-      followHubVM.searchFollowUsers(by: newValue) { success in
+      followHubVM.searchFollowUsers(by: newValue, userId: userId) { success in
         if success {
           searchedFollowingUser = followHubVM.followingSearchResult
           searchedFollowerUser = followHubVM.followerSearchResult
@@ -124,18 +126,15 @@ struct SearchedUserListView: View {
       }
     }
     .refreshable {
-      followHubVM.initFollowingUsers { _ in
-        followHubVM.initFollowerUsers { _ in
-          followHubVM.searchFollowUsers(by: nameToSearch) { success in
-            if success {
-              searchedFollowingUser = followHubVM.followingSearchResult
-              searchedFollowerUser = followHubVM.followerSearchResult
-            }
-          }
+      followHubVM.searchFollowUsers(by: nameToSearch, userId: userId) { success in
+        if success {
+          searchedFollowingUser = followHubVM.followingSearchResult
+          searchedFollowerUser = followHubVM.followerSearchResult
         }
       }
     }
   }
+
 
   private func showList(of users: [FollowUserData], followType: FollowType) -> some View {
     ForEach(users) { user in

--- a/Odya-iOS/Core/Follow/View/FollowUserListView.swift
+++ b/Odya-iOS/Core/Follow/View/FollowUserListView.swift
@@ -9,17 +9,11 @@ import SwiftUI
 
 // MARK: Follow User List View
 
-/// 팔로잉/팔로워 리스트 뷰
-/// 일정 구간에서 알 수도 있는 친구 추천하는 뷰를 띄워줌
-struct FollowUserListView: View {
-  @EnvironmentObject var followHubVM: FollowHubViewModel
-  @Binding var displayedUsers: [FollowUserData]
-
-  init(of users: Binding<[FollowUserData]>) {
-    self._displayedUsers = users
-  }
-
-  var body: some View {
+extension FollowHubView {
+  
+  /// 팔로잉/팔로워 리스트 뷰
+  /// 일정 구간에서 알 수도 있는 친구 추천하는 뷰를 띄워줌
+  var FollowUserListView: some View {
     ScrollView {
       VStack(spacing: 16) {
         showList(of: displayedUsers)
@@ -48,10 +42,12 @@ struct FollowUserListView: View {
         switch followHubVM.currentFollowType {
         case .following:
           UserIdentityRowWithFollowing(of: user)
-            .environmentObject(followHubVM)
         case .follower:
-          FollowerUserRowView(of: user)
-            .environmentObject(followHubVM)
+          if isMyFollowHub {
+            FollowerUserRowView(of: user)
+          } else {
+            UserIdentityRowWithFollowing(of: user)
+          }
         }
       }
       .padding(.horizontal, GridLayout.side)

--- a/Odya-iOS/Core/Follow/View/FollowerUserRowView.swift
+++ b/Odya-iOS/Core/Follow/View/FollowerUserRowView.swift
@@ -10,8 +10,6 @@ import SwiftUI
 /// 팔로워 리스트의 row 뷰
 /// 팔로워 유저의 프로필사진, 닉네임(팔로우 유저 뷰)과 삭제 버튼 포함
 struct FollowerUserRowView: View {
-  @EnvironmentObject var followHubVM: FollowHubViewModel
-
   let followUser: FollowUserData
   @State private var showingFollwerDeleteAlert: Bool = false
 
@@ -26,11 +24,12 @@ struct FollowerUserRowView: View {
                        profileUrl: followUser.profile.profileUrl,
                        isFollowing: followUser.isFollowing)
       Spacer()
-      if followHubVM.userID == MyData.userID {
+      if followUser.userId != MyData.userID {
         followerDeletionButton
       }
     }
     .frame(height: 36)
+    
   }
   
   private var followerDeletionButton: some View {

--- a/Odya-iOS/Core/Follow/View/FollowerUserRowView.swift
+++ b/Odya-iOS/Core/Follow/View/FollowerUserRowView.swift
@@ -29,7 +29,6 @@ struct FollowerUserRowView: View {
       }
     }
     .frame(height: 36)
-    
   }
   
   private var followerDeletionButton: some View {

--- a/Odya-iOS/Core/Home/PlaceDetail/ViewModel/PlaceDetailViewModel.swift
+++ b/Odya-iOS/Core/Home/PlaceDetail/ViewModel/PlaceDetailViewModel.swift
@@ -84,7 +84,7 @@ final class PlaceDetailViewModel: ObservableObject {
   func fetchVisitingUser(placeId: String) {
     if placeId.isEmpty { return }
     
-    followProvider.requestPublisher(.getVisitingUser(placeID: placeId))
+    followProvider.requestPublisher(.getVisitingUser(placeId: placeId))
       .sink { completion in
         switch completion {
         case .finished:

--- a/Odya-iOS/Core/TravelJournal/TravelJournalCompose/View/TravelJournalInfoView.swift
+++ b/Odya-iOS/Core/TravelJournal/TravelJournalCompose/View/TravelJournalInfoView.swift
@@ -10,7 +10,6 @@ import SwiftUI
 // MARK: Travel Info Edit Section
 struct TravelJournalInfoEditView: View {
   @EnvironmentObject var journalComposeVM: JournalComposeViewModel
-  @StateObject var followHubVM = FollowHubViewModel()
 
   private let titleCharacterLimit = 20
 
@@ -94,7 +93,6 @@ struct TravelJournalInfoEditView: View {
       NavigationLink(destination: {
         TravelMateSelectorView()
           .environmentObject(journalComposeVM)
-          .environmentObject(followHubVM)
           .navigationBarHidden(true)
       }) {
         Image("plus").padding(6)


### PR DESCRIPTION
### 개요
- 타인의 친구관리 뷰에 나오는 팔로우 버튼 수정

### 변경사항
- 팔로우 버튼 초기값 api 로 받아온 isFollowing 으로 변경
- 타인의 팔로워 리스트인 경우 팔로워 삭제 버튼이 아닌 팔로우 버튼 나오도록 수정
- 자잘한 오류 수정
    - 친구관리 뷰에 처음 들어갔을 때 리스트가 제대로 뜨지 않는 오류(새로고침 한 번은 해줘야 나옴..) 해결
- 검색 api 라우터 수정 ( 하지만 이 api 는 현재 사용 안하고 있습니당... )

### 관련 지라 및 위키 링크
- [ODUA-253](https://weit.atlassian.net/browse/ODYA-253)

### 리뷰어에게 하고 싶은 말

https://github.com/weIT-1st/Odya-iOS/assets/70556633/5df78994-43dd-41cf-aa15-029dd05a37ff


