### PR TITLE
FEAT: ODYA-272 여행일지 작성 시 사진 위치 정보

### DIFF
--- a/Odya-iOS/Core/TravelJournal/DailyJournalEdit/ViewModel/DailyJournalEditViewModel.swift
+++ b/Odya-iOS/Core/TravelJournal/DailyJournalEdit/ViewModel/DailyJournalEditViewModel.swift
@@ -113,6 +113,17 @@ class DailyJournalEditViewModel: ObservableObject {
       let deletedImagesId: [Int] = originalJournal.images.filter { !fetchedImages.contains($0) }.map
       { $0.imageId }
       debugPrint(deletedImagesId)
+      
+      // 사진 위치 정보 정리
+      // TODO: 삭제된 사진의 위치 정보 처리
+      var newLatitudes = latitudes
+      newLatitudes += selectedImages.compactMap {
+        $0.location?.latitude
+      }
+      var newLongitudes = longitudes
+      newLongitudes += selectedImages.compactMap {
+        $0.location?.longitude
+      }
 
       // api 호출
       _ = try await updateDailyJournalAPI(

--- a/Odya-iOS/Core/TravelJournal/TravelJournalCompose/ViewModel/JournalComposeViewModel.swift
+++ b/Odya-iOS/Core/TravelJournal/TravelJournalCompose/ViewModel/JournalComposeViewModel.swift
@@ -247,6 +247,19 @@ class JournalComposeViewModel: ObservableObject {
       // webp 변환하기
       let images = dailyJournalList.flatMap { $0.selectedImages }
       let webPImages = await webPImageManager.processImages(images: images)
+      
+      // 사진 위치 정보 정리
+      dailyJournalList.indices.forEach { idx in
+        let images = dailyJournalList[idx].selectedImages
+        dailyJournalList[idx].latitudes = images.compactMap {
+          $0.location?.latitude
+        }
+        dailyJournalList[idx].longitudes = images.compactMap {
+          $0.location?.longitude
+        }
+      }
+      
+      debugPrint(dailyJournalList)
 
       // api 호출
       _ = try await createJournalAPI(idToken: idToken, webpImages: webPImages)

--- a/Odya-iOS/Core/TravelJournal/TravelJournalCompose/ViewModel/JournalComposeViewModel.swift
+++ b/Odya-iOS/Core/TravelJournal/TravelJournalCompose/ViewModel/JournalComposeViewModel.swift
@@ -258,8 +258,6 @@ class JournalComposeViewModel: ObservableObject {
           $0.location?.longitude
         }
       }
-      
-      debugPrint(dailyJournalList)
 
       // api 호출
       _ = try await createJournalAPI(idToken: idToken, webpImages: webPImages)


### PR DESCRIPTION
### 개요
- 여행일지 작성 시 사진의 위치 정보 추가
- 여행일지 일정 수정 시 기존의 위치정보에 새로운 사진 위치 정보 추가

### 변경사항

### 관련 지라 및 위키 링크
- [ODYA-272](https://weit.atlassian.net/browse/ODYA-272)

### 리뷰어에게 하고 싶은 말
- 사진 위치 정보를 각 일정 latitude와 longitude 배열에 추가하고 있습니다..!
- 여행일지 일정 수정 시에는 삭제된 사진의 위치정보를 기존의 latitides, longitudes와 매칭할 방법이 없어 사진은 삭제하되 위치정보는 그대로 유지하고 있습니다...ㅠ