### PR TITLE
FEAT: ODYA-275 여행일지 임시저장

### DIFF
--- a/Odya-iOS/Core/TravelJournal/TravelJournalCompose/View/ContentComposeView.swift
+++ b/Odya-iOS/Core/TravelJournal/TravelJournalCompose/View/ContentComposeView.swift
@@ -199,6 +199,20 @@ struct ContentComposeView: View {
     } label: {
       PlaceTagButton(placeName: placeName)
     }
+    .task {
+      if dailyJournal.placeId != nil && placeName == nil {
+        dailyJournal.placeId?.placeIdToName {
+          self.placeName = $0
+        }
+      }
+    }
+    .onChange(of: dailyJournal.placeId) { newValue in
+      if newValue != nil && placeName == nil {
+        newValue?.placeIdToName {
+          self.placeName = $0
+        }
+      }
+    }
   }
 }
 

--- a/Odya-iOS/Core/TravelJournal/TravelJournalCompose/View/TravelJournalComposeView.swift
+++ b/Odya-iOS/Core/TravelJournal/TravelJournalCompose/View/TravelJournalComposeView.swift
@@ -17,6 +17,7 @@ struct TravelJournalComposeView: View {
 
   @State private var isDismissAlertVisible = false
   @State private var isRegisterAlertVisible = false
+  @State private var isGetTempDataAlertVisible = false
 
   private var privacyTypeToggleOffset: CGFloat {
     switch journalComposeVM.privacyType {
@@ -85,11 +86,29 @@ struct TravelJournalComposeView: View {
         }
       }
       .onAppear {
+        // 임시저장 중인 여행일지 불러오기
+        let tempData = TempTravelJournalData()
+        if tempData.dataExist {
+          if composeType == .create && tempData.journalId == -1
+              || (composeType == .edit && tempData.journalId == journalId) {
+            isGetTempDataAlertVisible = true
+          }
+        }
+        
         // 여행일지 작성 시 데일리 일정 초기화
         if composeType == .create
-          && journalComposeVM.dailyJournalList.isEmpty
-        {
+          && journalComposeVM.dailyJournalList.isEmpty {
           journalComposeVM.addDailyJournal()
+        }
+      }
+      .alert("작성 중인 여행일지가 있습니다.", isPresented: $isGetTempDataAlertVisible) {
+        Button("취소", role: .cancel) {
+          journalComposeVM.deleteTemporaryTravelJournal()
+          isGetTempDataAlertVisible = false
+        }
+        Button("불러오기") {
+          journalComposeVM.loadTemporaryTravelJournal()
+          isGetTempDataAlertVisible = false
         }
       }
 
@@ -115,7 +134,10 @@ struct TravelJournalComposeView: View {
       // 뒤로가기 버튼 클릭 시 alert
       .confirmationDialog("", isPresented: $isDismissAlertVisible) {
         // TODO: 임시저장
-        // Button("임시저장") { print("임시저장 클릭") }
+        Button("임시저장") {
+          journalComposeVM.saveTempraryTravelJournal()
+          dismiss()
+        }
         Button("작성취소", role: .destructive) {
           print("작성취소 클릭")
           dismiss()

--- a/Odya-iOS/Core/TravelJournal/TravelJournalCompose/ViewModel/JournalComposeViewModel.swift
+++ b/Odya-iOS/Core/TravelJournal/TravelJournalCompose/ViewModel/JournalComposeViewModel.swift
@@ -333,6 +333,47 @@ class JournalComposeViewModel: ObservableObject {
     .store(in: &subscription)
   }
 
+  // MARK: Functions - save temporary
+  
+  func saveTempraryTravelJournal() {
+    var tempData = TempTravelJournalData()
+    tempData.dataExist = true
+    tempData.journalId = self.journalId
+    tempData.title = self.title
+    tempData.startDate = self.startDate
+    tempData.endDate = self.endDate
+    tempData.mates = self.travelMates.map { $0.encodeToString() }
+    tempData.privacyType = self.privacyType.toString()
+  }
+  
+  func loadTemporaryTravelJournal() {
+    let tempData = TempTravelJournalData()
+    
+    if tempData.dataExist == false {
+      return
+    }
+    
+    self.title = tempData.title
+    self.startDate = tempData.startDate
+    self.endDate = tempData.endDate
+    self.travelMates = tempData.mates.compactMap { $0.decodeToTravelMate() }
+    self.privacyType = tempData.privacyType.toJournalPrivacyType()
+    
+    deleteTemporaryTravelJournal()
+  }
+  
+  func deleteTemporaryTravelJournal() {
+    var tempData = TempTravelJournalData()
+    
+    tempData.dataExist = false
+    tempData.journalId = -1
+    tempData.title = ""
+    tempData.startDate = Date()
+    tempData.endDate = Date()
+    tempData.mates = [String]()
+    tempData.privacyType = ""
+  }
+  
   // MARK: Functions - daily journal
 
   func canAddMoreDailyJournals() -> Bool {

--- a/Odya-iOS/Core/TravelJournal/TravelJournalCompose/ViewModel/JournalComposeViewModel.swift
+++ b/Odya-iOS/Core/TravelJournal/TravelJournalCompose/ViewModel/JournalComposeViewModel.swift
@@ -344,6 +344,7 @@ class JournalComposeViewModel: ObservableObject {
     tempData.endDate = self.endDate
     tempData.mates = self.travelMates.map { $0.encodeToString() }
     tempData.privacyType = self.privacyType.toString()
+    tempData.dailyJournals = self.dailyJournalList.map { $0.encodeToString() }
   }
   
   func loadTemporaryTravelJournal() {
@@ -358,6 +359,7 @@ class JournalComposeViewModel: ObservableObject {
     self.endDate = tempData.endDate
     self.travelMates = tempData.mates.compactMap { $0.decodeToTravelMate() }
     self.privacyType = tempData.privacyType.toJournalPrivacyType()
+    self.dailyJournalList = tempData.dailyJournals.compactMap { $0.decodeToDailyJournal() }
     
     deleteTemporaryTravelJournal()
   }
@@ -372,6 +374,7 @@ class JournalComposeViewModel: ObservableObject {
     tempData.endDate = Date()
     tempData.mates = [String]()
     tempData.privacyType = ""
+    tempData.dailyJournals = [String]()
   }
   
   // MARK: Functions - daily journal

--- a/Odya-iOS/Model/EditedDailyTravelJournal.swift
+++ b/Odya-iOS/Model/EditedDailyTravelJournal.swift
@@ -79,3 +79,47 @@ extension DailyTravelJournal: Comparable {
     return dateL < dateR
   }
 }
+
+// MARK: 데일리 일정 임시저장
+
+struct TempDailyJournal: Codable {
+  var date: Date?
+  var content: String
+  var placeId: String?
+  
+  var dailyJournalId: Int = -1
+  var isOriginal: Bool = false
+  
+  init(from dailyJournal: DailyTravelJournal) {
+    self.date = dailyJournal.date
+    self.content = dailyJournal.content
+    self.placeId = dailyJournal.placeId
+    
+    self.dailyJournalId = dailyJournal.dailyJournalId
+    self.isOriginal = dailyJournal.isOriginal
+  }
+}
+
+extension DailyTravelJournal {
+  func encodeToString() -> String {
+    let tempDailyJournal = TempDailyJournal(from: self)
+    if let encodedData = try? JSONEncoder().encode(tempDailyJournal) {
+      return String(data: encodedData, encoding: .utf8) ?? ""
+    }
+    return ""
+  }
+}
+
+extension String {
+  func decodeToDailyJournal() -> DailyTravelJournal? {
+    if let data = self.data(using: .utf8),
+       let decodedData = try? JSONDecoder().decode(TempDailyJournal.self, from: data) {
+      return DailyTravelJournal(date: decodedData.date,
+                                content: decodedData.content,
+                                placeId: decodedData.placeId,
+                                dailyJournalId: decodedData.dailyJournalId,
+                                isOriginal: decodedData.isOriginal)
+    }
+    return nil
+  }
+}

--- a/Odya-iOS/Model/TravelMate.swift
+++ b/Odya-iOS/Model/TravelMate.swift
@@ -40,6 +40,26 @@ extension TravelMate: Equatable {
   }
 }
 
+extension TravelMate {
+  func encodeToString() -> String {
+    if let encodedData = try? JSONEncoder().encode(self) {
+      return String(data: encodedData, encoding: .utf8) ?? ""
+    }
+    return ""
+  }
+}
+
+extension String {
+  func decodeToTravelMate() -> TravelMate? {
+    if let data = self.data(using: .utf8),
+       let decodedData = try? JSONDecoder().decode(TravelMate.self, from: data) {
+      return decodedData
+    }
+    return nil
+  }
+}
+
+
 struct travelMateSimple: Codable, Identifiable {
   var id = UUID()
   var username: String

--- a/Odya-iOS/Model/UserDefaults.swift
+++ b/Odya-iOS/Model/UserDefaults.swift
@@ -122,6 +122,8 @@ struct TempTravelJournalData {
   @UserDefault(key: keyEnum_TempTravelJournal.privacyType.rawValue, defaultValue: "")
   var privacyType
   
+  @UserDefault(key: keyEnum_TempTravelJournal.dailyJournals.rawValue, defaultValue: [String]())
+  var dailyJournals: [String]
 }
 
 enum keyEnum_MyData: String {
@@ -151,4 +153,5 @@ enum keyEnum_TempTravelJournal: String {
   case endDate
   case mates
   case privacyType
+  case dailyJournals
 }

--- a/Odya-iOS/Model/UserDefaults.swift
+++ b/Odya-iOS/Model/UserDefaults.swift
@@ -99,6 +99,31 @@ struct SearchUserData {
   static var recentSearchUser: [SearchedUserContent]?
 }
 
+/// 여행일지 임시저장
+struct TempTravelJournalData {
+  @UserDefault(key: keyEnum_TempTravelJournal.temporaryJournalExists.rawValue, defaultValue: false)
+  var dataExist: Bool
+  
+  @UserDefault(key: keyEnum_TempTravelJournal.journalId.rawValue, defaultValue: -1)
+  var journalId: Int
+
+  @UserDefault(key: keyEnum_TempTravelJournal.title.rawValue, defaultValue: "")
+  var title: String
+
+  @UserDefault(key: keyEnum_TempTravelJournal.startDate.rawValue, defaultValue: Date())
+  var startDate: Date
+  
+  @UserDefault(key: keyEnum_TempTravelJournal.endDate.rawValue, defaultValue: Date())
+  var endDate: Date
+  
+  @UserDefault(key: keyEnum_TempTravelJournal.mates.rawValue, defaultValue: [String]())
+  var mates: [String]
+  
+  @UserDefault(key: keyEnum_TempTravelJournal.privacyType.rawValue, defaultValue: "")
+  var privacyType
+  
+}
+
 enum keyEnum_MyData: String {
   case userId
   case nickname
@@ -116,4 +141,14 @@ enum keyEnum_APPLE_USER: String {
 enum keyEnum_Search: String {
   case recentSearchText
   case recentSearchUser
+}
+
+enum keyEnum_TempTravelJournal: String {
+  case temporaryJournalExists
+  case journalId
+  case title
+  case startDate
+  case endDate
+  case mates
+  case privacyType
 }


### PR DESCRIPTION
### 개요
- 여행일지 작성/수정 시 임시 저장 기능 추가

### 변경사항
- 여행일지 임시저장 alert 추가
- 여행일지 작성 시 임시저장 된 파일이 있을 경우 불러오기 alert 띄워줌
- 여행일지 수정 시 해당 journalId로 임시저장된 데이터가 있을 경우 불러오기 alert 띄워줌
- 임시저장 된 데이터를 불러올 때 placeName을 나오게 하기 위해 cjournalContentCompose 부분에서 placeId로 placeName 구하는 기능 추가

### 관련 지라 및 위키 링크
- [ODYA-275](https://weit.atlassian.net/browse/ODYA-275)

### 리뷰어에게 하고 싶은 말
- 데일리 일정 편집 부분에는 임시저장 기능을 추가하지 않았습니다.

https://github.com/weIT-1st/Odya-iOS/assets/70556633/08f15a25-c436-44dd-acc1-be9fd3a988c6

