### PR TITLE
FEAT: ODYA-291 알림 이미지 저장

### DIFF
--- a/NotificationServiceExtension/Model/NotificationIconState.swift
+++ b/NotificationServiceExtension/Model/NotificationIconState.swift
@@ -1,0 +1,19 @@
+//
+//  NotificationIconState.swift
+//  NotificationServiceExtension
+//
+//  Created by Jade Yoo on 2024/02/20.
+//
+
+import Foundation
+import RealmSwift
+
+class NotificationIconState: Object {
+  @Persisted(primaryKey: true) var _id: ObjectId
+  @Persisted var unreadNotificationExists: Bool
+  
+  convenience init(unreadNotificationExists: Bool) {
+    self.init()
+    self.unreadNotificationExists = unreadNotificationExists
+  }
+}

--- a/NotificationServiceExtension/NotificationService.swift
+++ b/NotificationServiceExtension/NotificationService.swift
@@ -29,6 +29,25 @@ class NotificationService: UNNotificationServiceExtension {
       print("Data payload 확인: \(bestAttemptContent.userInfo)")
       saveNotificationData(userInfo: bestAttemptContent.userInfo)
       
+      // handle image
+      guard let contentImage = bestAttemptContent.userInfo["contentImage"] as? String else {
+        contentHandler(bestAttemptContent)
+        return
+      }
+      
+      let imageURL = URL(string: contentImage)!
+      
+      // 이미지 다운로드
+      guard let imageData = try? Data(contentsOf: imageURL) else {
+        contentHandler(bestAttemptContent)
+        return
+      }
+      
+      guard let attachment = UNNotificationAttachment.saveImageToDisk(identifier: contentImage, data: imageData) else {
+        contentHandler(bestAttemptContent)
+        return
+      }
+      bestAttemptContent.attachments = [attachment]
       contentHandler(bestAttemptContent)
     }
   }

--- a/NotificationServiceExtension/NotificationService.swift
+++ b/NotificationServiceExtension/NotificationService.swift
@@ -16,7 +16,7 @@ class NotificationService: UNNotificationServiceExtension {
   private var realm: Realm {
     let container = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: "group.com.weit.Odya-iOS")
     let realmURL = container?.appendingPathComponent("default.realm")
-    let config = Realm.Configuration(fileURL: realmURL, schemaVersion: 1)
+    let config = Realm.Configuration(fileURL: realmURL, schemaVersion: 2)
     return try! Realm(configuration: config)
   }
   
@@ -47,7 +47,7 @@ class NotificationService: UNNotificationServiceExtension {
     let communityId = Int(data["communityId"] as? String ?? "")
     let travelJournalId = Int(data["travelJournalId"] as? String ?? "")
     let followerId = Int(data["followerId"] as? String ?? "")
-    let commentContent = data["commentContent"] as? String
+    let commentContent = data["content"] as? String
     let contentImage = data["contentImage"] as? String
     let userProfileUrl = data["userProfileUrl"] as? String
     let profileColorHex = data["profileColorHex"] as? String
@@ -71,6 +71,31 @@ class NotificationService: UNNotificationServiceExtension {
       }
     } catch {
       print("알림 데이터 저장 실패")
+      return
+    }
+    
+    updateIconState()
+  }
+  
+  private func updateIconState() {
+    if let state = realm.objects(NotificationIconState.self).first {
+      // update
+      do {
+        try realm.write {
+          state.unreadNotificationExists = true
+        }
+      } catch {
+        print("알림 아이콘 상태 업데이트 실패")
+      }
+    } else {
+      let newState = NotificationIconState(unreadNotificationExists: true)
+      do {
+        try realm.write {
+          realm.add(newState)
+        }
+      } catch {
+        print("알림 아이콘 상태 저장 실패")
+      }
     }
   }
 }

--- a/NotificationServiceExtension/UNNotificationAttachment+Extension.swift
+++ b/NotificationServiceExtension/UNNotificationAttachment+Extension.swift
@@ -9,23 +9,9 @@ import UIKit
 import UserNotifications
 
 extension UNNotificationAttachment {
-  static func saveImageToDisk(identifier: String, data: Data, options: [AnyHashable : Any]? = nil) -> UNNotificationAttachment? {
+  static func attachImageData(identifier: String, data: Data, options: [AnyHashable : Any]? = nil) -> UNNotificationAttachment? {
     let fileManager = FileManager.default
-    guard let container = fileManager.containerURL(forSecurityApplicationGroupIdentifier: "group.com.weit.Odya-iOS") else {
-      return nil
-    }
-    
-    let directoryURL = container.appendingPathComponent("Thumbnails")
-    
-    // 썸네일 디렉토리가 없으면 생성
-    if !fileManager.fileExists(atPath: directoryURL.path) {
-      do {
-        try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: true)
-      } catch {
-        print("Failed to create folder")
-        return nil
-      }
-    }
+    let documentURL = fileManager.urls(for: .documentDirectory, in: .userDomainMask)[0]
     
     // 이미지 파일 이름 수정
     guard let fileName = identifier.split(separator: "/").last?.replacingOccurrences(of: ".webp", with: ".jpeg") else {
@@ -36,16 +22,12 @@ extension UNNotificationAttachment {
       return nil
     }
     
+    let attachmentURL = documentURL.appendingPathComponent(fileName)
+    fileManager.createFile(atPath: attachmentURL.path, contents: jpegData)
+    
     // 이미지 데이터 저장
     do {
-      let fileURL = directoryURL.appendingPathComponent(fileName)
-      print("🔥 fileURL: \(fileURL)")
-      try jpegData.write(to: fileURL, options: .noFileProtection)
-      
-      let flag = fileManager.fileExists(atPath: fileURL.path)
-      print("🔥 fileExists: \(flag)")
-      
-      let attachment = try UNNotificationAttachment(identifier: identifier, url: fileURL, options: options)
+      let attachment = try UNNotificationAttachment(identifier: identifier, url: attachmentURL, options: options)
       return attachment
     } catch {
       print("Failed to save image to disk with \(error.localizedDescription)")

--- a/NotificationServiceExtension/UNNotificationAttachment+Extension.swift
+++ b/NotificationServiceExtension/UNNotificationAttachment+Extension.swift
@@ -1,0 +1,51 @@
+//
+//  UNNotificationAttachment+Extension.swift
+//  NotificationServiceExtension
+//
+//  Created by Jade Yoo on 2024/02/20.
+//
+
+import UIKit
+import UserNotifications
+
+extension UNNotificationAttachment {
+  static func saveImageToDisk(identifier: String, data: Data, options: [AnyHashable : Any]? = nil) -> UNNotificationAttachment? {
+    let fileManager = FileManager.default
+    guard let container = fileManager.containerURL(forSecurityApplicationGroupIdentifier: "group.com.weit.Odya-iOS") else {
+      return nil
+    }
+    
+    let directoryURL = container.appendingPathComponent("Thumbnails")
+    
+    // 썸네일 디렉토리가 없으면 생성
+    if !fileManager.fileExists(atPath: directoryURL.path) {
+      do {
+        try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+      } catch {
+        print("Failed to create folder")
+        return nil
+      }
+    }
+    
+    // 이미지 파일 이름 수정
+    guard let fileName = identifier.split(separator: "/").last?.replacingOccurrences(of: ".webp", with: ".jpeg") else {
+      return nil
+    }
+    // jpeg 파일로 변경 (webp는 알림에서 지원되지 않음)
+    guard let jpegData = UIImage(data: data)?.jpegData(compressionQuality: 0.8) else {
+      return nil
+    }
+    
+    // 이미지 데이터 저장
+    do {
+      let fileURL = directoryURL.appendingPathComponent(fileName)
+      try jpegData.write(to: fileURL)
+      let attachment = try UNNotificationAttachment(identifier: identifier, url: fileURL, options: options)
+      return attachment
+    } catch {
+      print("Failed to save image to disk with \(error.localizedDescription)")
+    }
+    
+    return nil
+  }
+}

--- a/NotificationServiceExtension/UNNotificationAttachment+Extension.swift
+++ b/NotificationServiceExtension/UNNotificationAttachment+Extension.swift
@@ -39,7 +39,12 @@ extension UNNotificationAttachment {
     // 이미지 데이터 저장
     do {
       let fileURL = directoryURL.appendingPathComponent(fileName)
-      try jpegData.write(to: fileURL)
+      print("🔥 fileURL: \(fileURL)")
+      try jpegData.write(to: fileURL, options: .noFileProtection)
+      
+      let flag = fileManager.fileExists(atPath: fileURL.path)
+      print("🔥 fileExists: \(flag)")
+      
       let attachment = try UNNotificationAttachment(identifier: identifier, url: fileURL, options: options)
       return attachment
     } catch {

--- a/Odya-iOS.xcodeproj/project.pbxproj
+++ b/Odya-iOS.xcodeproj/project.pbxproj
@@ -74,6 +74,7 @@
 		194417982B218A4A00423541 /* LinkedTravelJournalCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 194417972B218A4A00423541 /* LinkedTravelJournalCell.swift */; };
 		1944179A2B21C0B500423541 /* LinkedTravelJournalViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 194417992B21C0B500423541 /* LinkedTravelJournalViewModel.swift */; };
 		194894BB2B68819E00D8A7FE /* CustomMarkerIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 194894BA2B68819E00D8A7FE /* CustomMarkerIconView.swift */; };
+		1956E5BC2B8470F5006995E6 /* UNNotificationAttachment+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1956E5BB2B8470F5006995E6 /* UNNotificationAttachment+Extension.swift */; };
 		195BF2F72ACE525A00E4FEDD /* CommunityRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 195BF2F62ACE525A00E4FEDD /* CommunityRouter.swift */; };
 		195BF2F92ACE755400E4FEDD /* ShowMoreJournalButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 195BF2F82ACE755400E4FEDD /* ShowMoreJournalButton.swift */; };
 		19683AFB2B0304B9003D6013 /* CommunityCommentRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19683AFA2B0304B9003D6013 /* CommunityCommentRouter.swift */; };
@@ -388,6 +389,7 @@
 		194417972B218A4A00423541 /* LinkedTravelJournalCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedTravelJournalCell.swift; sourceTree = "<group>"; };
 		194417992B21C0B500423541 /* LinkedTravelJournalViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedTravelJournalViewModel.swift; sourceTree = "<group>"; };
 		194894BA2B68819E00D8A7FE /* CustomMarkerIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomMarkerIconView.swift; sourceTree = "<group>"; };
+		1956E5BB2B8470F5006995E6 /* UNNotificationAttachment+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UNNotificationAttachment+Extension.swift"; sourceTree = "<group>"; };
 		195BF2F62ACE525A00E4FEDD /* CommunityRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunityRouter.swift; sourceTree = "<group>"; };
 		195BF2F82ACE755400E4FEDD /* ShowMoreJournalButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShowMoreJournalButton.swift; sourceTree = "<group>"; };
 		19683AFA2B0304B9003D6013 /* CommunityCommentRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunityCommentRouter.swift; sourceTree = "<group>"; };
@@ -963,11 +965,12 @@
 		192D66CD2B7DBA3200CDE9D2 /* NotificationServiceExtension */ = {
 			isa = PBXGroup;
 			children = (
-				192D66E52B7DFBAD00CDE9D2 /* Model */,
+				192D66D02B7DBA3200CDE9D2 /* Info.plist */,
 				192D66D92B7DF69E00CDE9D2 /* NotificationServiceExtensionDebug.entitlements */,
 				192D66D82B7DF67A00CDE9D2 /* NotificationServiceExtensionRelease.entitlements */,
+				192D66E52B7DFBAD00CDE9D2 /* Model */,
 				192D66CE2B7DBA3200CDE9D2 /* NotificationService.swift */,
-				192D66D02B7DBA3200CDE9D2 /* Info.plist */,
+				1956E5BB2B8470F5006995E6 /* UNNotificationAttachment+Extension.swift */,
 			);
 			path = NotificationServiceExtension;
 			sourceTree = "<group>";
@@ -1964,6 +1967,7 @@
 			files = (
 				192D66E72B844F6800CDE9D2 /* NotificationIconState.swift in Sources */,
 				192D66E42B7DFBA800CDE9D2 /* NotificationData.swift in Sources */,
+				1956E5BC2B8470F5006995E6 /* UNNotificationAttachment+Extension.swift in Sources */,
 				192D66CF2B7DBA3200CDE9D2 /* NotificationService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Odya-iOS.xcodeproj/project.pbxproj
+++ b/Odya-iOS.xcodeproj/project.pbxproj
@@ -64,6 +64,8 @@
 		192D66E02B7DF8C600CDE9D2 /* Realm in Frameworks */ = {isa = PBXBuildFile; productRef = 192D66DF2B7DF8C600CDE9D2 /* Realm */; };
 		192D66E22B7DF8C600CDE9D2 /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 192D66E12B7DF8C600CDE9D2 /* RealmSwift */; };
 		192D66E42B7DFBA800CDE9D2 /* NotificationData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 192D66E32B7DFBA800CDE9D2 /* NotificationData.swift */; };
+		192D66E72B844F6800CDE9D2 /* NotificationIconState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 192D66E62B844F6800CDE9D2 /* NotificationIconState.swift */; };
+		192D66E92B8452DC00CDE9D2 /* NotificationIconState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 192D66E82B8452DC00CDE9D2 /* NotificationIconState.swift */; };
 		19385A342B2AC16A000CB6AB /* MyCommunityActivityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19385A332B2AC16A000CB6AB /* MyCommunityActivityView.swift */; };
 		19385A362B2AF08F000CB6AB /* MyCommunityActivityViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19385A352B2AF08F000CB6AB /* MyCommunityActivityViewModel.swift */; };
 		19385A382B2C07C3000CB6AB /* MyCommunityCommentCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19385A372B2C07C2000CB6AB /* MyCommunityCommentCell.swift */; };
@@ -376,6 +378,8 @@
 		192D66D82B7DF67A00CDE9D2 /* NotificationServiceExtensionRelease.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = NotificationServiceExtensionRelease.entitlements; sourceTree = "<group>"; };
 		192D66D92B7DF69E00CDE9D2 /* NotificationServiceExtensionDebug.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = NotificationServiceExtensionDebug.entitlements; sourceTree = "<group>"; };
 		192D66E32B7DFBA800CDE9D2 /* NotificationData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationData.swift; sourceTree = "<group>"; };
+		192D66E62B844F6800CDE9D2 /* NotificationIconState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationIconState.swift; sourceTree = "<group>"; };
+		192D66E82B8452DC00CDE9D2 /* NotificationIconState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationIconState.swift; sourceTree = "<group>"; };
 		19385A332B2AC16A000CB6AB /* MyCommunityActivityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyCommunityActivityView.swift; sourceTree = "<group>"; };
 		19385A352B2AF08F000CB6AB /* MyCommunityActivityViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyCommunityActivityViewModel.swift; sourceTree = "<group>"; };
 		19385A372B2C07C2000CB6AB /* MyCommunityCommentCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyCommunityCommentCell.swift; sourceTree = "<group>"; };
@@ -923,6 +927,7 @@
 				3E2F29812B2F274B00FF5357 /* Review.swift */,
 				19E3C1C32B63A6670037A495 /* CoordinateImage.swift */,
 				07083A9B2B819539003CAA5A /* NotificationData.swift */,
+				192D66E82B8452DC00CDE9D2 /* NotificationIconState.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -971,6 +976,7 @@
 			isa = PBXGroup;
 			children = (
 				192D66E32B7DFBA800CDE9D2 /* NotificationData.swift */,
+				192D66E62B844F6800CDE9D2 /* NotificationIconState.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -1796,6 +1802,7 @@
 				3E9E98932A8B7C7300909653 /* UserInfoValidatorRouter.swift in Sources */,
 				3EBEC3A82A6D483400998EC6 /* CheckboxButton.swift in Sources */,
 				3E2F296C2B29BAA000FF5357 /* FavoritePlaceInProfileViewModel.swift in Sources */,
+				192D66E92B8452DC00CDE9D2 /* NotificationIconState.swift in Sources */,
 				3E1124A02B64501D007F3549 /* UserSuggestionByContactsViewModel.swift in Sources */,
 				19F9286C2B60D5CF009CDDCB /* ShowMoreButton.swift in Sources */,
 				3E4670162B13611100B54D0A /* AppIntroductionView.swift in Sources */,
@@ -1955,6 +1962,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				192D66E72B844F6800CDE9D2 /* NotificationIconState.swift in Sources */,
 				192D66E42B7DFBA800CDE9D2 /* NotificationData.swift in Sources */,
 				192D66CF2B7DBA3200CDE9D2 /* NotificationService.swift in Sources */,
 			);
@@ -2196,9 +2204,11 @@
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CODE_SIGN_ENTITLEMENTS = NotificationServiceExtension/NotificationServiceExtensionDebug.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 22;
-				DEVELOPMENT_TEAM = 7V2ZG69KPK;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 7V2ZG69KPK;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = NotificationServiceExtension/Info.plist;
@@ -2215,6 +2225,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.weit.Odya-iOS.NotificationServiceExtension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "ODYA-NSE-Development-Profile-240219";
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -2229,9 +2240,11 @@
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CODE_SIGN_ENTITLEMENTS = NotificationServiceExtension/NotificationServiceExtensionRelease.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 22;
-				DEVELOPMENT_TEAM = 7V2ZG69KPK;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 7V2ZG69KPK;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = NotificationServiceExtension/Info.plist;
@@ -2248,6 +2261,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.weit.Odya-iOS.NotificationServiceExtension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "ODYA-NSE-AppStore-Profile-240219";
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -2413,11 +2427,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 19EBA7512AB16B7D000ABBE5 /* XCRemoteSwiftPackageReference "Moya" */;
 			productName = Moya;
-		};
-		3E11AFD02B13216200AFD288 /* FirebaseMessaging */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 3EBEC38F2A6B1C2600998EC6 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
-			productName = FirebaseMessaging;
 		};
 		19FF88BB2B68CF0B00FA6B46 /* GoogleMapsUtils */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Odya-iOS/Core/Community/Notification/FeedNotificationView.swift
+++ b/Odya-iOS/Core/Community/Notification/FeedNotificationView.swift
@@ -71,28 +71,17 @@ struct FeedNotificationView: View {
       }
       Spacer()
       // image
-      if let contentImage = content.thumbnailImage {
-        contentImage
-          .resizable()
-          .aspectRatio(contentMode: .fill)
-          .frame(width: 50, height: 50)
-          .clipped()
-      } else {
-        defaultContentImage
+      if let _ = content.contentImage {
+        if let contentImage = content.thumbnailImage {
+          contentImage
+            .resizable()
+            .aspectRatio(contentMode: .fill)
+            .frame(width: 50, height: 50)
+            .clipped()
+        } else {
+          defaultContentImage
+        }
       }
-
-//      if let imageUrl = content.contentImage {
-//        AsyncImage(url: URL(string: imageUrl)) { image in
-//          image
-//            .resizable()
-//            .aspectRatio(contentMode: .fill)
-//            .frame(width: 50, height: 50)
-//            .clipped()
-//        } placeholder: {
-//          ProgressView()
-//            .frame(width: 50, height: 50)
-//        }
-//      }
     }
   }
   

--- a/Odya-iOS/Core/Community/Notification/FeedNotificationView.swift
+++ b/Odya-iOS/Core/Community/Notification/FeedNotificationView.swift
@@ -35,7 +35,7 @@ struct FeedNotificationView: View {
   // cell
   private func notificationContentCell(content: NotificationData) -> some View {
     HStack(alignment: .top, spacing: 10) {
-      ProfileImageView(of: "", profileData: content.profileData, size: .S)
+      ProfileImageView(profileUrl: content.userProfileUrl ?? "", size: .S)
       // content
       let event = NotificationEventType(rawValue: content.eventType)
       switch event {

--- a/Odya-iOS/Core/Community/Notification/FeedNotificationView.swift
+++ b/Odya-iOS/Core/Community/Notification/FeedNotificationView.swift
@@ -32,10 +32,25 @@ struct FeedNotificationView: View {
     .toolbar(.hidden)
   }
   
+  private let profileSize = ComponentSizeType.S.ProfileImageSize
   // cell
   private func notificationContentCell(content: NotificationData) -> some View {
     HStack(alignment: .top, spacing: 10) {
-      ProfileImageView(profileUrl: content.userProfileUrl ?? "", size: .S)
+      // profile
+      if let profileImage = content.profileImage {
+        profileImage
+          .resizable()
+          .aspectRatio(contentMode: .fill)
+          .frame(width: profileSize, height: profileSize)
+          .clipped()
+          .background(Color.odya.system.inactive)
+          .cornerRadius(profileSize / 2)
+      } else {
+        Image("profile")
+          .resizable()
+          .aspectRatio(contentMode: .fill)
+          .frame(width: profileSize, height: profileSize)
+      }
       // content
       let event = NotificationEventType(rawValue: content.eventType)
       switch event {
@@ -56,16 +71,14 @@ struct FeedNotificationView: View {
       }
       Spacer()
       // image
-      if let _ = content.contentImage {
-        if let contentImage = content.thumbnailImage {
-          contentImage
-            .resizable()
-            .aspectRatio(contentMode: .fill)
-            .frame(width: 50, height: 50)
-            .clipped()
-        } else {
-          defaultContentImage
-        }
+      if let contentImage = content.thumbnailImage {
+        contentImage
+          .resizable()
+          .aspectRatio(contentMode: .fill)
+          .frame(width: 50, height: 50)
+          .clipped()
+      } else {
+        defaultContentImage
       }
 
 //      if let imageUrl = content.contentImage {

--- a/Odya-iOS/Core/Community/Notification/FeedNotificationView.swift
+++ b/Odya-iOS/Core/Community/Notification/FeedNotificationView.swift
@@ -56,19 +56,40 @@ struct FeedNotificationView: View {
       }
       Spacer()
       // image
-      if let imageUrl = content.contentImage {
-        AsyncImage(url: URL(string: imageUrl)) { image in
-          image
+      if let _ = content.contentImage {
+        if let contentImage = content.thumbnailImage {
+          contentImage
             .resizable()
             .aspectRatio(contentMode: .fill)
             .frame(width: 50, height: 50)
             .clipped()
-        } placeholder: {
-          ProgressView()
-            .frame(width: 50, height: 50)
+        } else {
+          defaultContentImage
         }
       }
+
+//      if let imageUrl = content.contentImage {
+//        AsyncImage(url: URL(string: imageUrl)) { image in
+//          image
+//            .resizable()
+//            .aspectRatio(contentMode: .fill)
+//            .frame(width: 50, height: 50)
+//            .clipped()
+//        } placeholder: {
+//          ProgressView()
+//            .frame(width: 50, height: 50)
+//        }
+//      }
     }
+  }
+  
+  private var defaultContentImage: some View {
+    Image("logo-lightgray")
+      .resizable()
+      .aspectRatio(contentMode: .fit)
+      .padding(12)
+      .frame(width: 50, height: 50)
+      .background(Color.odya.background.dimmed_dark)
   }
   
   private func boldText(_ text: String) -> Text {

--- a/Odya-iOS/Core/Community/Notification/FeedNotificationViewModel.swift
+++ b/Odya-iOS/Core/Community/Notification/FeedNotificationViewModel.swift
@@ -29,6 +29,19 @@ final class FeedNotificationViewModel: ObservableObject {
     self.notificationList = Array(tasks)
     
     setAllNotificationsRead()
+    
+    let fileManager = FileManager.default
+    guard let container = fileManager.containerURL(forSecurityApplicationGroupIdentifier: "group.com.weit.Odya-iOS") else {
+      return
+    }
+    let directoryURL = container.appendingPathComponent("Thumbnails")
+    
+    do {
+      let fileURLs = try fileManager.contentsOfDirectory(atPath: directoryURL.path)
+      print("앱 그룹 내부 폴더 \(fileURLs)")
+    } catch {
+      print("Error reading directory \(error)")
+    }
   }
   
   /// 알림을 모두 읽은 상태로 설정

--- a/Odya-iOS/Core/Community/Notification/FeedNotificationViewModel.swift
+++ b/Odya-iOS/Core/Community/Notification/FeedNotificationViewModel.swift
@@ -29,19 +29,6 @@ final class FeedNotificationViewModel: ObservableObject {
     self.notificationList = Array(tasks)
     
     setAllNotificationsRead()
-    
-    let fileManager = FileManager.default
-    guard let container = fileManager.containerURL(forSecurityApplicationGroupIdentifier: "group.com.weit.Odya-iOS") else {
-      return
-    }
-    let directoryURL = container.appendingPathComponent("Thumbnails")
-    
-    do {
-      let fileURLs = try fileManager.contentsOfDirectory(atPath: directoryURL.path)
-      print("앱 그룹 내부 폴더 \(fileURLs)")
-    } catch {
-      print("Error reading directory \(error)")
-    }
   }
   
   /// 알림을 모두 읽은 상태로 설정

--- a/Odya-iOS/Core/Community/Notification/FeedNotificationViewModel.swift
+++ b/Odya-iOS/Core/Community/Notification/FeedNotificationViewModel.swift
@@ -14,7 +14,7 @@ final class FeedNotificationViewModel: ObservableObject {
   private var realm: Realm {
     let container = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: "group.com.weit.Odya-iOS")
     let realmURL = container?.appendingPathComponent("default.realm")
-    let config = Realm.Configuration(fileURL: realmURL, schemaVersion: 1)
+    let config = Realm.Configuration(fileURL: realmURL, schemaVersion: 2)
     return try! Realm(configuration: config)
   }
   
@@ -27,5 +27,20 @@ final class FeedNotificationViewModel: ObservableObject {
     let tasks = realm.objects(NotificationData.self).sorted(byKeyPath: "notifiedAt", ascending: false)
     print(tasks)
     self.notificationList = Array(tasks)
+    
+    setAllNotificationsRead()
+  }
+  
+  /// 알림을 모두 읽은 상태로 설정
+  private func setAllNotificationsRead() {
+    if let state = realm.objects(NotificationIconState.self).first {
+      do {
+        try realm.write {
+          state.unreadNotificationExists = false
+        }
+      } catch {
+        debugPrint("알림 아이콘 상태 변경 실패")
+      }
+    }
   }
 }

--- a/Odya-iOS/Core/Community/View/FeedView.swift
+++ b/Odya-iOS/Core/Community/View/FeedView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import RealmSwift
 
 enum FeedRoute: Hashable {
   case detail(Int)
@@ -116,6 +117,7 @@ struct FeedView: View {
               if viewModel.state.content.isEmpty {
                 viewModel.fetchAllFeedNextPageIfPossible()
               }
+              viewModel.getNotificationState()
             }
           }
           .background(Color.odya.background.normal)
@@ -193,7 +195,7 @@ struct FeedView: View {
 
       // alarm on/off
       NavigationLink(value: FeedRoute.notification) {
-        Image("alarm-on")
+        Image(viewModel.unreadNotificationExists ? "alarm-on" : "alarm-off")
           .padding(10)
           .frame(width: 48, height: 48, alignment: .center)
       }

--- a/Odya-iOS/Core/Profile/Settings/ViewModel/UserInfoEditViewModel.swift
+++ b/Odya-iOS/Core/Profile/Settings/ViewModel/UserInfoEditViewModel.swift
@@ -315,6 +315,7 @@ class UserInfoEditViewModel: ObservableObject {
   @MainActor
   func logout() {
     appDataManager.deleteMyData()
+    appDataManager.deleteLocalDB()
     switch authType {
     case "kakao":
       KakaoAuthViewModel().kakaoLogout()
@@ -339,6 +340,7 @@ class UserInfoEditViewModel: ObservableObject {
         switch completion {
         case .finished:
           self.appDataManager.deleteMyData()
+          self.appDataManager.deleteLocalDB()
           self.idToken = nil
           self.authType = ""
           self.authState = .loggedOut

--- a/Odya-iOS/Managers/AppDataManager.swift
+++ b/Odya-iOS/Managers/AppDataManager.swift
@@ -9,6 +9,7 @@ import Combine
 import CombineMoya
 import FirebaseAuth
 import Moya
+import RealmSwift
 import SwiftUI
 
 class AppDataManager: ObservableObject {
@@ -22,6 +23,14 @@ class AppDataManager: ObservableObject {
   
   // token
   @AppStorage("WeITAuthToken") var idToken: String?
+  
+  // realm
+  private var realm: Realm {
+    let container = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: "group.com.weit.Odya-iOS")
+    let realmURL = container?.appendingPathComponent("default.realm")
+    let config = Realm.Configuration(fileURL: realmURL, schemaVersion: 2)
+    return try! Realm(configuration: config)
+  }
   
   // MARK: Refresh Token
   
@@ -104,5 +113,11 @@ class AppDataManager: ObservableObject {
     MyData.userID = -1
     MyData.nickname = ""
     MyData.profile = ""
+  }
+  
+  func deleteLocalDB() {
+    try? realm.write {
+      realm.deleteAll()
+    }
   }
 }

--- a/Odya-iOS/Model/NotificationData.swift
+++ b/Odya-iOS/Model/NotificationData.swift
@@ -5,7 +5,7 @@
 //  Created by Jade Yoo on 2024/02/18.
 //
 
-import Foundation
+import SwiftUI
 import RealmSwift
 
 enum NotificationEventType: String {
@@ -54,6 +54,31 @@ class NotificationData: Object {
     case .none:
       return ""
     }
+  }
+  
+  var thumbnailImage: Image? {
+    let fileManager = FileManager.default
+    guard let container = fileManager.containerURL(forSecurityApplicationGroupIdentifier: "group.com.weit.Odya-iOS") else {
+      return nil
+    }
+    
+    let directoryURL = container.appendingPathComponent("Thumbnails")
+    
+    guard let fileName = contentImage?.split(separator: "/").last?.replacingOccurrences(of: ".webp", with: ".jpeg") else {
+      return nil
+    }
+    
+    let fileURL = directoryURL.appendingPathComponent(fileName, conformingTo: .jpeg)
+
+    let flag = fileManager.fileExists(atPath: fileURL.path)
+    print("🥲 fileExists: \(flag)")
+
+    guard let uiImage = UIImage(contentsOfFile: fileURL.path) else {
+      print("🔥 이미지 변환 실패")
+      return nil
+    }
+    
+    return Image(uiImage: uiImage)
   }
   
   convenience init(eventType: String, userName: String, notifiedAt: String, communityId: Int? = nil, travelJournalId: Int? = nil, followerId: Int? = nil, commentContent: String? = nil, contentImage: String? = nil, userProfileUrl: String? = nil, profileColorHex: String? = nil) {

--- a/Odya-iOS/Model/NotificationData.swift
+++ b/Odya-iOS/Model/NotificationData.swift
@@ -56,25 +56,26 @@ class NotificationData: Object {
     }
   }
   
+  var profileImage: Image? {
+    guard let path = getImageFilePath(imageURL: userProfileUrl) else {
+      return nil
+    }
+
+    guard let uiImage = UIImage(contentsOfFile: path) else {
+      debugPrint("이미지 변환 실패")
+      return nil
+    }
+    
+    return Image(uiImage: uiImage)
+  }
+  
   var thumbnailImage: Image? {
-    let fileManager = FileManager.default
-    guard let container = fileManager.containerURL(forSecurityApplicationGroupIdentifier: "group.com.weit.Odya-iOS") else {
+    guard let path = getImageFilePath(imageURL: contentImage) else {
       return nil
     }
-    
-    let directoryURL = container.appendingPathComponent("Thumbnails")
-    
-    guard let fileName = contentImage?.split(separator: "/").last?.replacingOccurrences(of: ".webp", with: ".jpeg") else {
-      return nil
-    }
-    
-    let fileURL = directoryURL.appendingPathComponent(fileName, conformingTo: .jpeg)
 
-    let flag = fileManager.fileExists(atPath: fileURL.path)
-    print("🥲 fileExists: \(flag)")
-
-    guard let uiImage = UIImage(contentsOfFile: fileURL.path) else {
-      print("🔥 이미지 변환 실패")
+    guard let uiImage = UIImage(contentsOfFile: path) else {
+      debugPrint("이미지 변환 실패")
       return nil
     }
     
@@ -93,5 +94,26 @@ class NotificationData: Object {
     self.contentImage = contentImage
     self.userProfileUrl = userProfileUrl
     self.profileColorHex = profileColorHex
+  }
+  
+  func getImageFilePath(imageURL: String?) -> String? {
+    guard let imageURLString = imageURL else {
+      return nil
+    }
+    
+    let fileManager = FileManager.default
+    guard let container = fileManager.containerURL(forSecurityApplicationGroupIdentifier: "group.com.weit.Odya-iOS") else {
+      return nil
+    }
+    
+    let directoryURL = container.appendingPathComponent("Thumbnails")
+    let fileName = URL(string: imageURLString)!.lastPathComponent
+    let fileURL = directoryURL.appendingPathComponent(fileName, conformingTo: .webP)
+    
+    if !fileManager.fileExists(atPath: fileURL.path) {
+      return nil
+    }
+    
+    return fileURL.path
   }
 }

--- a/Odya-iOS/Model/NotificationIconState.swift
+++ b/Odya-iOS/Model/NotificationIconState.swift
@@ -1,0 +1,19 @@
+//
+//  NotificationIconState.swift
+//  Odya-iOS
+//
+//  Created by Jade Yoo on 2024/02/20.
+//
+
+import Foundation
+import RealmSwift
+
+class NotificationIconState: Object {
+  @Persisted(primaryKey: true) var _id: ObjectId
+  @Persisted var unreadNotificationExists: Bool
+  
+  convenience init(unreadNotificationExists: Bool) {
+    self.init()
+    self.unreadNotificationExists = unreadNotificationExists
+  }
+}

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -15,6 +15,8 @@
 
 default_platform(:ios)
 
+xcode_select "/Applications/Xcode-15.0.1.app"
+
 platform :ios do
   # 에러처리
   error do |lane, exception, options|
@@ -73,9 +75,10 @@ platform :ios do
       scheme: "Odya-iOS",
       export_method: "app-store",
       export_options: {
-	      provisioningProfiles: {
-	       "com.weit.Odya-iOS" => "ODYA-AppStore-Profile-240131"
-	      }
+	provisioningProfiles: {
+	  "com.weit.Odya-iOS" => "ODYA-AppStore-Profile-240215",
+	  "com.weit.Odya-iOS.NotificationServiceExtension" => "ODYA-NSE-AppStore-Profile-240219"
+	}
       }
     )
     


### PR DESCRIPTION
### 개요
알림의 이미지 데이터를 기기에 저장

### 변경사항
1. 피드 상단의 알림 아이콘 변경
- 빨간점 O, X

2. Notification Service Extension
- 컨텐츠 이미지, 프로필 이미지 저장
- 푸쉬 알림에 사진 띄우기

3. 로그아웃, 회원탈퇴 시 Realm data 삭제

**결과**
- 푸쉬 알림 수신

https://github.com/weIT-1st/Odya-iOS/assets/26922015/88e2622e-7d23-4ea4-a728-b63c6ddaa706

- 알림 내역
<img src="https://github.com/weIT-1st/Odya-iOS/assets/26922015/17d1eae0-cff2-4c31-87bb-b9c49348d183" width=300>

### 관련 지라 및 위키 링크
[ODYA-291](https://weit.atlassian.net/browse/ODYA-291)

### 리뷰어에게 하고 싶은 말
알림이 오는 시점에 이미지 주소를 저장해도 시간이 지나면 주소가 바뀌므로 알림의 이미지 데이터를 기기에 저장합니다
