### PR TITLE
FEAT: ODYA-279 화면전환 수정

### DIFF
--- a/NotificationServiceExtension/NotificationService.swift
+++ b/NotificationServiceExtension/NotificationService.swift
@@ -45,7 +45,9 @@ class NotificationService: UNNotificationServiceExtension {
         }
       }
       */
-
+      
+      saveNotificationData(userInfo: bestAttemptContent.userInfo)
+      
       // handle image
       guard let contentImage = bestAttemptContent.userInfo["contentImage"] as? String else {
         contentHandler(bestAttemptContent)

--- a/Odya-iOS.xcodeproj/project.pbxproj
+++ b/Odya-iOS.xcodeproj/project.pbxproj
@@ -19,6 +19,9 @@
 		07310DAF2A6BB0CD0047E972 /* ReviewRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07310DAE2A6BB0CD0047E972 /* ReviewRouter.swift */; };
 		07310DB62A7286380047E972 /* ReviewApiService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07310DB52A7286380047E972 /* ReviewApiService.swift */; };
 		0732948A2A2C9975008E1026 /* UserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 073294892A2C9975008E1026 /* UserDefaults.swift */; };
+		07347B8B2B94B72C0072D3C5 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07347B8A2B94B72C0072D3C5 /* AppState.swift */; };
+		07347B8E2B94C2800072D3C5 /* Tab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07347B8D2B94C2800072D3C5 /* Tab.swift */; };
+		07347B902B94C3E90072D3C5 /* NavStacks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07347B8F2B94C3E90072D3C5 /* NavStacks.swift */; };
 		07589E682AE80B0B00867FAD /* TopicLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07589E672AE80B0B00867FAD /* TopicLayout.swift */; };
 		07589E6A2AE9345100867FAD /* AuthInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07589E692AE9345100867FAD /* AuthInterceptor.swift */; };
 		07589E6C2AEFC7F300867FAD /* FeedDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07589E6B2AEFC7F300867FAD /* FeedDetailViewModel.swift */; };
@@ -336,6 +339,9 @@
 		07310DAE2A6BB0CD0047E972 /* ReviewRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewRouter.swift; sourceTree = "<group>"; };
 		07310DB52A7286380047E972 /* ReviewApiService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewApiService.swift; sourceTree = "<group>"; };
 		073294892A2C9975008E1026 /* UserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaults.swift; sourceTree = "<group>"; };
+		07347B8A2B94B72C0072D3C5 /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
+		07347B8D2B94C2800072D3C5 /* Tab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tab.swift; sourceTree = "<group>"; };
+		07347B8F2B94C3E90072D3C5 /* NavStacks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavStacks.swift; sourceTree = "<group>"; };
 		07589E672AE80B0B00867FAD /* TopicLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicLayout.swift; sourceTree = "<group>"; };
 		07589E692AE9345100867FAD /* AuthInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthInterceptor.swift; sourceTree = "<group>"; };
 		07589E6B2AEFC7F300867FAD /* FeedDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedDetailViewModel.swift; sourceTree = "<group>"; };
@@ -703,6 +709,7 @@
 		071FA52F2A20ADA400C7B362 /* App */ = {
 			isa = PBXGroup;
 			children = (
+				07347B8C2B94C26F0072D3C5 /* AppState */,
 				071FA5212A20A99F00C7B362 /* Odya_iOSApp.swift */,
 				3E0589002A276E84005C29D9 /* AppDelegate.swift */,
 				3E0589022A276E8C005C29D9 /* SceneDelegate.swift */,
@@ -785,6 +792,16 @@
 				1906B97F2B55271A0043DCF8 /* PlaceReviewCell.swift */,
 			);
 			path = Review;
+			sourceTree = "<group>";
+		};
+		07347B8C2B94C26F0072D3C5 /* AppState */ = {
+			isa = PBXGroup;
+			children = (
+				07347B8A2B94B72C0072D3C5 /* AppState.swift */,
+				07347B8D2B94C2800072D3C5 /* Tab.swift */,
+				07347B8F2B94C3E90072D3C5 /* NavStacks.swift */,
+			);
+			path = AppState;
 			sourceTree = "<group>";
 		};
 		0761F1972AD8043F00FB87AA /* ViewModel */ = {
@@ -1820,6 +1837,7 @@
 				3ED8DBB02B10A7ED00D7CF7F /* PhotoLibraryAuthorizatiionChecker.swift in Sources */,
 				19E3C1C02B634BF30037A495 /* PlaceTextView.swift in Sources */,
 				19683AFE2B030BEE003D6013 /* CommentViewModel.swift in Sources */,
+				07347B902B94C3E90072D3C5 /* NavStacks.swift in Sources */,
 				3EBEC3A22A6C38EC00998EC6 /* ComponetsTestView.swift in Sources */,
 				3E075C912B230A1C0093CACD /* PofileInfoSection.swift in Sources */,
 				3ED22F652AAE3BFD0067DE72 /* FollowHubViewModel.swift in Sources */,
@@ -1908,6 +1926,7 @@
 				07AF2B192A392F0500D54780 /* LocationSearchView.swift in Sources */,
 				19385A342B2AC16A000CB6AB /* MyCommunityActivityView.swift in Sources */,
 				3EBEC3B52A6FFC3500998EC6 /* CTAButton.swift in Sources */,
+				07347B8E2B94C2800072D3C5 /* Tab.swift in Sources */,
 				3E07A6612B500A8500E93B6E /* FavoritePlaceBookmarkManager.swift in Sources */,
 				3E26C37F2AF0E80E003607A8 /* DailyJournalViewModel.swift in Sources */,
 				3E4670202B15E90A00B54D0A /* FollowView.swift in Sources */,
@@ -1955,6 +1974,7 @@
 				3EEBB7CD2A8E259800F0049D /* TravelJournalComposeView.swift in Sources */,
 				07B221242B491D32006C2B20 /* ReviewComposeView.swift in Sources */,
 				3EF54A052A5BE9A8006562F8 /* Response.swift in Sources */,
+				07347B8B2B94B72C0072D3C5 /* AppState.swift in Sources */,
 				3E800EC52A3E16D4001EA4C4 /* PhotoPickerView.swift in Sources */,
 				0773639D2B4AE4B7007F37CA /* TransparentFullScreenCover.swift in Sources */,
 				19EBA7692AB437C6000ABBE5 /* FeedUserInfoView.swift in Sources */,
@@ -2121,10 +2141,12 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "Odya-iOS/Odya-iOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 28;
 				DEVELOPMENT_ASSET_PATHS = "\"Odya-iOS/Preview Content\"";
-				DEVELOPMENT_TEAM = 7V2ZG69KPK;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 7V2ZG69KPK;
 				ENABLE_PREVIEWS = YES;
 				EXCLUDED_ARCHS = "";
 				GENERATE_INFOPLIST_FILE = YES;
@@ -2150,6 +2172,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.weit.Odya-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "ODYA-Development-Profile-240215";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -2213,7 +2236,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 22;
+				CURRENT_PROJECT_VERSION = 28;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 7V2ZG69KPK;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
@@ -2249,7 +2272,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 22;
+				CURRENT_PROJECT_VERSION = 28;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 7V2ZG69KPK;
 				GCC_C_LANGUAGE_STANDARD = gnu17;

--- a/Odya-iOS/App/AppState/AppState.swift
+++ b/Odya-iOS/App/AppState/AppState.swift
@@ -1,0 +1,13 @@
+//
+//  AppState.swift
+//  Odya-iOS
+//
+//  Created by Jade Yoo on 2024/03/03.
+//
+
+import SwiftUI
+
+final class AppState: ObservableObject {
+  @Published var activeTab: Tab = .home
+  @Published var feedNavStack: [FeedStack] = []
+}

--- a/Odya-iOS/App/AppState/NavStacks.swift
+++ b/Odya-iOS/App/AppState/NavStacks.swift
@@ -1,0 +1,17 @@
+//
+//  NavStacks.swift
+//  Odya-iOS
+//
+//  Created by Jade Yoo on 2024/03/03.
+//
+
+import Foundation
+
+enum FeedStack: Hashable {
+  case detail(Int)
+  case createFeed
+  case createJournal
+  case activity
+  case notification
+  case journalDetail(Int)
+}

--- a/Odya-iOS/App/AppState/Tab.swift
+++ b/Odya-iOS/App/AppState/Tab.swift
@@ -1,0 +1,41 @@
+//
+//  Tab.swift
+//  Odya-iOS
+//
+//  Created by Jade Yoo on 2024/03/03.
+//
+
+import Foundation
+
+enum Tab: CaseIterable {
+  case home
+  case journal
+  case feed
+  case profile
+  
+  var title: String {
+    switch self {
+    case .home:
+      return "홈"
+    case .journal:
+      return "내추억"
+    case .feed:
+      return "피드"
+    case .profile:
+      return "내정보"
+    }
+  }
+  
+  var symbolImage: String {
+    switch self {
+    case .home:
+      return "location-m"
+    case .journal:
+      return "diary"
+    case .feed:
+      return "messages-off"
+    case .profile:
+      return "person-off"
+    }
+  }
+}

--- a/Odya-iOS/App/Odya_iOSApp.swift
+++ b/Odya-iOS/App/Odya_iOSApp.swift
@@ -101,6 +101,7 @@ struct Odya_iOSApp: App {
           case .loggedIn,
               .additionalSetupRequired:
             RootTabView()
+              .environmentObject(appDelegate.appState)
               .onAppear {
                 if authState == .additionalSetupRequired {
                   isShowingAdditionalSetUpView = true

--- a/Odya-iOS/Core/Community/CommunityCompose/CommunityComposeView.swift
+++ b/Odya-iOS/Core/Community/CommunityCompose/CommunityComposeView.swift
@@ -33,6 +33,7 @@ enum CommunityComposeMode {
 struct CommunityComposeView: View {
   // MARK: Properties
   @Environment(\.presentationMode) var presentationMode
+  @EnvironmentObject var appState: AppState
   
   /// 커뮤니티 아이디
   var communityId: Int = -1
@@ -72,19 +73,15 @@ struct CommunityComposeView: View {
   /// 탭뷰 Dot indicator 높이
   private let dotIndicatorHeight: CGFloat = 44
 
-  /// 내비게이션 스택 경로
-  @Binding var path: NavigationPath
   /// 커뮤니티 작성 모드
   let composeMode: CommunityComposeMode
   
   // MARK: - Init
-  init(path: Binding<NavigationPath>) {
-    self._path = path
+  init() {
     self.composeMode = .create
   }
   
-  init(path: Binding<NavigationPath>, feedDetail: FeedDetail) {
-    self._path = path
+  init(feedDetail: FeedDetail) {
     self.composeMode = .edit
     self.communityId = feedDetail.communityId
     self._textContent = State(initialValue: feedDetail.content)
@@ -236,7 +233,7 @@ struct CommunityComposeView: View {
   /// 여행일지 불러오기 버튼
   private var connectTravelJournalButton: some View {
     NavigationLink {
-      LinkedTravelJournalView(path: $path, selectedJournalId: $travelJournalId, selectedJournalTitle: $travelJournalTitle, headerTitle: "여행일지")
+      LinkedTravelJournalView(selectedJournalId: $travelJournalId, selectedJournalTitle: $travelJournalTitle, headerTitle: "여행일지")
     } label: {
       ZStack {
         HStack(alignment: .center, spacing: 16) {

--- a/Odya-iOS/Core/Community/Notification/FeedNotificationView.swift
+++ b/Odya-iOS/Core/Community/Notification/FeedNotificationView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct FeedNotificationView: View {
   @StateObject private var viewModel = FeedNotificationViewModel()
+  @EnvironmentObject var appState: AppState
   
   var body: some View {
     VStack(spacing: 0) {
@@ -16,8 +17,23 @@ struct FeedNotificationView: View {
       ScrollView(.vertical) {
         LazyVStack(spacing: 20) {
           ForEach(viewModel.notificationList, id: \._id) { noti in
-            // TODO: Navigation Link
             notificationContentCell(content: noti)
+              .onTapGesture {
+                switch noti.event {
+                case .followingCommunity, .communityComment, .communityLike:
+                  if let id = noti.communityId {
+                    appState.feedNavStack.append(.detail(id))
+                  }
+                case .followingTravelJournal, .travelJournalTag:
+                  if let id = noti.travelJournalId {
+                    appState.feedNavStack.append(.journalDetail(id))
+                  }
+                case .followerAdd:
+                  appState.activeTab = .profile
+                case .none:
+                  break
+                }
+              }
             Divider()
           }
         }
@@ -52,8 +68,7 @@ struct FeedNotificationView: View {
           .frame(width: profileSize, height: profileSize)
       }
       // content
-      let event = NotificationEventType(rawValue: content.eventType)
-      switch event {
+      switch content.event {
       case .followingCommunity:
         (boldText(content.userName) + regularText(" 님이 ") + coloredText(content.emphasizedWord) + regularText("를 작성했습니다")) + dateText(content.notifiedAt)
       case .followingTravelJournal:

--- a/Odya-iOS/Core/Community/View/FeedDetailView.swift
+++ b/Odya-iOS/Core/Community/View/FeedDetailView.swift
@@ -10,8 +10,7 @@ import SwiftUI
 struct FeedDetailView: View {
   // MARK: Properties
   @Environment(\.presentationMode) var presentationMode
-  
-  @Binding var path: NavigationPath
+  @EnvironmentObject var appState: AppState
   
   @StateObject private var viewModel = FeedDetailViewModel()
   /// 탭뷰 사진 인덱스
@@ -151,7 +150,7 @@ struct FeedDetailView: View {
     }
     .navigationDestination(isPresented: $showEditView) {
       if let feedDetail = viewModel.feedDetail {
-        CommunityComposeView(path: $path, feedDetail: feedDetail)
+        CommunityComposeView(feedDetail: feedDetail)
       }
     }
     .fullScreenCover(isPresented: $showReportView) {

--- a/Odya-iOS/Core/Community/View/FeedView.swift
+++ b/Odya-iOS/Core/Community/View/FeedView.swift
@@ -8,15 +8,6 @@
 import SwiftUI
 import RealmSwift
 
-enum FeedRoute: Hashable {
-  case detail(Int)
-  case createFeed
-  case createJournal
-  case activity
-  case notification
-  case journalDetail(Int)
-}
-
 enum FeedToggleType {
   case all
   case friend
@@ -24,7 +15,8 @@ enum FeedToggleType {
 
 struct FeedView: View {
   // MARK: Properties
-
+  @EnvironmentObject var appState: AppState
+  
   @StateObject private var viewModel = FeedViewModel()
   @StateObject var followHubVM = FollowHubViewModel()
   
@@ -33,12 +25,11 @@ struct FeedView: View {
   @State private var selectedTopicId = -1
   /// 검색뷰 토글
   @State private var showSearchView = false
-  @State private var path = NavigationPath()
   
   // MARK: - Body
 
   var body: some View {
-    NavigationStack(path: $path) {
+    NavigationStack(path: $appState.feedNavStack) {
       GeometryReader { _ in
         ZStack(alignment: .bottomTrailing) {
           VStack(spacing: 0) {
@@ -123,7 +114,7 @@ struct FeedView: View {
           .background(Color.odya.background.normal)
           
           // 피드 작성하기
-          NavigationLink(value: FeedRoute.createFeed) {
+          NavigationLink(value: FeedStack.createFeed) {
             WriteButton()
           }
           .padding(20)
@@ -133,12 +124,12 @@ struct FeedView: View {
           }
         }  // ZStack
         .toolbar(.hidden)
-        .navigationDestination(for: FeedRoute.self) { route in
+        .navigationDestination(for: FeedStack.self) { route in
           switch route {
           case let .detail(communityId):
-            FeedDetailView(path: $path, communityId: communityId)
+            FeedDetailView(communityId: communityId)
           case .createFeed:
-            CommunityComposeView(path: $path)
+            CommunityComposeView()
           case .createJournal:
             TravelJournalComposeView()
               .navigationBarHidden(true)
@@ -171,7 +162,7 @@ struct FeedView: View {
   private var feedToolBar: some View {
     HStack(alignment: .center) {
       // 내 커뮤니티 활동 뷰로 연결
-      NavigationLink(value: FeedRoute.activity) {
+      NavigationLink(value: FeedStack.activity) {
         ProfileImageView(of: MyData.nickname, profileData: MyData.profile.decodeToProileData(), size: .S)
           .overlay(
             RoundedRectangle(cornerRadius: 32)
@@ -194,7 +185,7 @@ struct FeedView: View {
       }
 
       // alarm on/off
-      NavigationLink(value: FeedRoute.notification) {
+      NavigationLink(value: FeedStack.notification) {
         Image(viewModel.unreadNotificationExists ? "alarm-on" : "alarm-off")
           .padding(10)
           .frame(width: 48, height: 48, alignment: .center)
@@ -275,7 +266,7 @@ struct FeedView: View {
 
       // 여행일지 연동
       if let journal = simpleTravelJournal {
-        NavigationLink(value: FeedRoute.journalDetail(journal.travelJournalId)) {
+        NavigationLink(value: FeedStack.journalDetail(journal.travelJournalId)) {
           HStack {
             Image("diary")
               .frame(width: 24, height: 24)

--- a/Odya-iOS/Core/Community/View/PostContentView.swift
+++ b/Odya-iOS/Core/Community/View/PostContentView.swift
@@ -41,7 +41,7 @@ struct PostContentView: View {
 
   var body: some View {
     VStack {
-      NavigationLink(value: FeedRoute.detail(communityId)) {
+      NavigationLink(value: FeedStack.detail(communityId)) {
         VStack {
           // 유저 정보
           HStack {

--- a/Odya-iOS/Core/Home/View/HomeView.swift
+++ b/Odya-iOS/Core/Home/View/HomeView.swift
@@ -70,7 +70,7 @@ struct HomeView: View {
       .navigationDestination(for: PlaceDetailRoute.self) { route in
         switch route {
         case let .feedDetail(communityId):
-          FeedDetailView(path: $path, communityId: communityId)
+          FeedDetailView(communityId: communityId)
         case let.journalDetail(journalId):
           TravelJournalDetailView(journalId: journalId)
             .navigationBarHidden(true)

--- a/Odya-iOS/Core/Profile/ProfileView.swift
+++ b/Odya-iOS/Core/Profile/ProfileView.swift
@@ -33,7 +33,7 @@ struct ProfileView: View {
 
   // navigation stack
   @Environment(\.dismiss) var dismiss
-  @EnvironmentObject var rootTabManager: RootTabManager
+  @EnvironmentObject var appState: AppState
   @State var path = NavigationPath()
 
   // journal compose
@@ -151,7 +151,6 @@ struct ProfileView: View {
                 favoritePlaceTitle
                 FavoritePlaceListView(
                   userId: userId,
-                  rootTabViewIdx: $rootTabManager.selectedTab,
                   path: $path
                 )
                 .environmentObject(favoritePlacesVM)

--- a/Odya-iOS/Core/Profile/SectionsInProfileView/FavoritePlaceSection.swift
+++ b/Odya-iOS/Core/Profile/SectionsInProfileView/FavoritePlaceSection.swift
@@ -18,9 +18,9 @@ extension ProfileView {
 struct FavoritePlaceListView: View {
   @EnvironmentObject var VM: FavoritePlaceInProfileViewModel
   // @EnvironmentObject var fullScreenManager: FullScreenCoverManager
-
+  @EnvironmentObject var appState: AppState
+  
   let userId: Int
-  @Binding var rootTabViewIdx: Int
   @Binding var path: NavigationPath
 
   @Environment(\.dismiss) var dismiss
@@ -65,7 +65,7 @@ struct FavoritePlaceListView: View {
       dismiss()  // 프로필 뷰 풀스크린 닫기
       // fullScreenManager.closeAll()
       path.removeLast(path.count)
-      rootTabViewIdx = 0  // 메인 뷰로 이동
+      appState.activeTab = .home  // 메인 뷰로 이동
     }) {
       HStack(spacing: 10) {
         Text("\(VM.placesCount - 4)개의 관심장소 더보기")

--- a/Odya-iOS/Core/Profile/TravelJournalInProfile/MainJournalSelectorView.swift
+++ b/Odya-iOS/Core/Profile/TravelJournalInProfile/MainJournalSelectorView.swift
@@ -27,7 +27,7 @@ struct MainJournalSelectorView: View {
   var body: some View {
     ZStack(alignment: .top) {
       LinkedTravelJournalView(
-        path: $path, selectedJournalId: $selectedJournalId,
+        selectedJournalId: $selectedJournalId,
         selectedJournalTitle: $selectedJournalTitle, headerTitle: "")
 
       headerBar

--- a/Odya-iOS/Core/RootTabView.swift
+++ b/Odya-iOS/Core/RootTabView.swift
@@ -7,50 +7,46 @@
 
 import SwiftUI
 
-class RootTabManager: ObservableObject {
-  @Published var selectedTab: Int = 0
-}
-
 struct RootTabView: View {
 
 //  @EnvironmentObject var alertManager: AlertManager
-  @StateObject var rootTabManager = RootTabManager()
+  @EnvironmentObject var appState: AppState
   // @StateObject var fullScreenManager = FullScreenCoverManager()
   
   // MARK: Body
 
   var body: some View {
-    TabView(selection: $rootTabManager.selectedTab) {
+    TabView(selection: $appState.activeTab) {
       // MARK: 홈
       HomeView()
-        .environmentObject(rootTabManager)
+        .environmentObject(appState)
         .tabItem {
-          GNBButton(iconImage: "location-m", text: "홈")
-        }.tag(0)
+          GNBButton(iconImage: Tab.home.symbolImage, text: Tab.home.title)
+        }.tag(Tab.home)
 
       // MARK: 내추억
       MyJournalsView()
-        .environmentObject(rootTabManager)
+        .environmentObject(appState)
         // .environmentObject(fullScreenManager)
         .tabItem {
-          GNBButton(iconImage: "diary", text: "내추억")
-        }.tag(1)
+          GNBButton(iconImage: Tab.journal.symbolImage, text: Tab.journal.title)
+        }.tag(Tab.journal)
 
       // MARK: 피드
       FeedView()
-        .environmentObject(rootTabManager)
+        .environmentObject(appState)
         // .environmentObject(fullScreenManager)
         .tabItem {
-          GNBButton(iconImage: "messages-off", text: "피드")
-        }.tag(2)
+          GNBButton(iconImage: Tab.feed.symbolImage, text: Tab.feed.title)
+        }.tag(Tab.feed)
 
       // MARK: 내정보
       ProfileView()
-        .environmentObject(rootTabManager)
+        .environmentObject(appState)
         // .environmentObject(fullScreenManager)
         .tabItem {
-          GNBButton(iconImage: "person-off", text: "내정보")
-        }.tag(3)
+          GNBButton(iconImage: Tab.profile.symbolImage, text: Tab.profile.title)
+        }.tag(Tab.profile)
     }.accentColor(.odya.brand.primary)
   }
 }

--- a/Odya-iOS/Core/TravelJournal/LinkedTravelJournal/View/LinkedTravelJournalView.swift
+++ b/Odya-iOS/Core/TravelJournal/LinkedTravelJournal/View/LinkedTravelJournalView.swift
@@ -10,11 +10,10 @@ import SwiftUI
 struct LinkedTravelJournalView: View {
   // MARK: Properties
   @Environment(\.dismiss) private var dismiss
+  @EnvironmentObject var appState: AppState
   @StateObject private var viewModel = LinkedTravelJournalViewModel()
   @State private var showChangeVisibilityAlert: Bool = false
 
-  /// 내비게이션 스택 경로
-  @Binding var path: NavigationPath
   /// 선택된 여행일지 아이디
   @Binding var selectedJournalId: Int?
   /// 상위 뷰에 표시될 여행일지 타이틀
@@ -93,8 +92,8 @@ struct LinkedTravelJournalView: View {
       }
       Button {
         // action: 여행일지 작성하기
-        path.removeLast(path.count)
-        path.append(FeedRoute.createJournal)
+        appState.feedNavStack.removeLast(appState.feedNavStack.count)
+        appState.feedNavStack.append(.createJournal)
       } label: {
         Text("작성하기")
       }

--- a/Odya-iOS/Model/NotificationData.swift
+++ b/Odya-iOS/Model/NotificationData.swift
@@ -36,8 +36,11 @@ class NotificationData: Object {
     return ProfileData(profileUrl: userProfileUrl ?? "", profileColor: ProfileColorData(colorHex: profileColorHex ?? "000000"))
   }
   
+  var event: NotificationEventType? {
+    return NotificationEventType(rawValue: eventType)
+  }
+  
   var emphasizedWord: String {
-    let event = NotificationEventType(rawValue: eventType)
     switch event {
     case .followingCommunity:
       return "피드"


### PR DESCRIPTION
### 개요
알림으로 화면전환

### 변경사항
- 기존의 RootTabManager와 피드 내비게이션을 AppState에서 모두 관리합니다.
- 푸쉬 알림을 눌렀을 때와 피드 알림뷰에서 저장된 알림을 클릭했을 때, 해당 뷰로 이동


https://github.com/weIT-1st/Odya-iOS/assets/26922015/86f5d854-2ae3-4136-885c-36a02d9b9270



### 관련 지라 및 위키 링크
[ODYA-279](https://weit.atlassian.net/browse/ODYA-279)

### 리뷰어에게 하고 싶은 말
피드알림뷰를 먼저 내비스택에 넣고 그 다음에 알림으로 보여줄 뷰를 스택에 넣는 식으로 바꿔서
피드 쪽 내비게이션 스택만 관리하도록 + 다른 부분의 내비 스택은 최대한 건드리지 않도록 했습니다.
그동안 고생많으셨어요..!